### PR TITLE
fix withdrawLiquidityFromSlot bug

### DIFF
--- a/test/unit/CollarEngine.t.sol
+++ b/test/unit/CollarEngine.t.sol
@@ -45,7 +45,7 @@ contract CollarEngineTest is Test, ICollarEngineErrors {
         pool1 = address(new CollarPool(address(engine), 1, address(token1), address(token2), 100, 9000));
     }
 
-    function mintTokensAndApprovePool(address recipient) internal {
+    function mintTokensAndApprovePool(address recipient) public {
         startHoax(recipient);
         token1.mint(recipient, 100_000);
         token2.mint(recipient, 100_000);

--- a/test/unit/CollarPoolConstraints.t.sol
+++ b/test/unit/CollarPoolConstraints.t.sol
@@ -70,7 +70,7 @@ contract CollarPoolConstraintsTest is Test, ICollarPoolState {
         mintTokensAndApprovePool(address(manager));
     }
 
-    function mintTokensAndApprovePool(address recipient) internal {
+    function mintTokensAndApprovePool(address recipient) public {
         startHoax(recipient);
         cashAsset.mint(recipient, 100_000 ether);
         collateralAsset.mint(recipient, 100_000 ether);
@@ -79,7 +79,7 @@ contract CollarPoolConstraintsTest is Test, ICollarPoolState {
         vm.stopPrank();
     }
 
-    function mintTokensToUserAndApprovePool(address user) internal {
+    function mintTokensToUserAndApprovePool(address user) public {
         startHoax(user);
         cashAsset.mint(user, 100_000 ether);
         collateralAsset.mint(user, 100_000 ether);
@@ -88,7 +88,7 @@ contract CollarPoolConstraintsTest is Test, ICollarPoolState {
         vm.stopPrank();
     }
 
-    function mintTokensToUserAndApproveManager(address user) internal {
+    function mintTokensToUserAndApproveManager(address user) public {
         startHoax(user);
         cashAsset.mint(user, 100_000 ether);
         collateralAsset.mint(user, 100_000 ether);

--- a/test/unit/CollarVaultManager.t.sol
+++ b/test/unit/CollarVaultManager.t.sol
@@ -77,7 +77,7 @@ contract CollarVaultManagerTest is Test {
         vm.label(user2, "Test User 2");
     }
 
-    function mintTokensToUserAndApprovePool(address user) internal {
+    function mintTokensToUserAndApprovePool(address user) public {
         startHoax(user);
         collateralAsset.mint(user, 100_000);
         cashAsset.mint(user, 100_000);
@@ -86,7 +86,7 @@ contract CollarVaultManagerTest is Test {
         vm.stopPrank();
     }
 
-    function mintTokensToUserAndApproveManager(address user) internal {
+    function mintTokensToUserAndApproveManager(address user) public {
         startHoax(user);
         collateralAsset.mint(user, 100_000);
         cashAsset.mint(user, 100_000);


### PR DESCRIPTION
* made all internal function from tests to be public
* Reimplement moveLiquidityFromSlot function 
* fix withdraw liquidity bug 

there was a bug in which the withdraw liquidity function wasnt really withdrawing liquidity from the slot, and tests were made to assume that was correct, seemed like a bug to me since i couldnt find any coherent reason for that to be intentional , if it was by7 design , this Pr will be cancelled / reworked 


> @kryptoklob note:  i implemented it by copying and reestructuring the code from the other fucntions , the OTHER way to do it would be to add a "shouldTransfer" parameter to the functions and calling them with that parameter set to false, but that would only be the case for internal calls so thought it didnt make sense , its not a big deal to rework but let me know 