### PR TITLE
Minor cleanup for paired nfts 

### DIFF
--- a/src/BorrowPositionNFT.sol
+++ b/src/BorrowPositionNFT.sol
@@ -97,6 +97,8 @@ contract BorrowPositionNFT is IBorrowPositionNFT, BaseGovernedNFT {
 
         // transfer the full loan amount on open
         cashAsset.safeTransfer(msg.sender, loanAmount);
+
+        emit BorrowedFromSwap(borrowId, msg.sender, collateralAmount, cashFromSwap, loanAmount);
     }
 
     /// @dev this is for use in rolls to open positions without repaying or swapping
@@ -368,7 +370,6 @@ contract BorrowPositionNFT is IBorrowPositionNFT, BaseGovernedNFT {
         view
         returns (uint)
     {
-        // calculate provider locked cash
         ProviderPositionNFT.LiquidityOffer memory offer = providerNFT.getOffer(offerId);
         uint putRange = BIPS_BASE - offer.putStrikeDeviation;
         uint callRange = offer.callStrikeDeviation - BIPS_BASE;

--- a/src/interfaces/IBorrowPositionNFT.sol
+++ b/src/interfaces/IBorrowPositionNFT.sol
@@ -56,6 +56,13 @@ interface IBorrowPositionNFT {
         uint expiration
     );
     event WithdrawalFromSettled(uint indexed borrowId, address indexed recipient, uint withdrawn);
+    event BorrowedFromSwap(
+        uint indexed borrowId,
+        address indexed sender,
+        uint collateralAmount,
+        uint cashFromSwap,
+        uint loanAmount
+    );
 
     // constants
     function MAX_SWAP_TWAP_DEVIATION_BIPS() external view returns (uint);


### PR DESCRIPTION
- Add event to log collateral and loan amounts.
- Move the collateral and loan amounts from storage to the event. This is because it's unused on chain, and because it is not being set when not swapping. 
- Simplify the internal calls chain and make it more readable.