### PR TITLE
Rename CollarEngine to ConfigHub

### DIFF
--- a/devdocs/collar.md
+++ b/devdocs/collar.md
@@ -5,14 +5,7 @@ TODO: Update these docs.
 
 ## Overview
 
-Collar Protocol consists of three main components.
-
-> The engine coordinates governance and sets system parameters.
-
-> Vaults are the primary user-facing component of the protocol.
-
-> Market makers provide liquidity via liquidity pools for vaults.
-
+TODO: update
 
 ## The Collar
 
@@ -48,68 +41,4 @@ Here's an example collar:
 
 ## Smart Contracts
 
-### Engine
-
-The Engine is the core governance and system control smart contract of the Collar Protocol.
-
-It is the canonical lookup hub for allowed assets, vault parameters, and liquidity pools.
-
-It will direct system fees and (eventually) contain governance for the protocol.
-
-### Vault
-
-Because vaults are conceptual objects, they can't be their own smart contracts - a user can have many vaults.
-
-Vaults are created, tracked, and managed via the `VaultManager` smart contract, which allows users to execute the following operations:
-
-- Create a new vault (given a collateral asset, a cash asset, a putstrike, and a callstrike)
-- Withdraw cash as a loan from an existing vault
-- Finalize an existing vault
-
-#### Vault Creation
-
-When a user creates a new vault, the following occurs:
-
-1) The user's collateral is swapped for cash at the current spot price (with allowed slippage parameters)
-
-2) The cash from the above swap is divided into two portions: the loan amount and the locked amount.
-
-3) The locked amount is used to mint a new ERC1155 token which represent's the user's Collar to the user.
-
-#### Vault Finalization
-
-1) The price of the collateral asset at time of vault closure is checked.
-
-2) The conversion rate of the ERC1155 token is set based on the price of the collateral asset at time of vault closure. This will allow the user to redeem the ERC1155 token for more or less than the original locked amount, depending on the price of the collateral asset at time of vault closure.
-
-3) The conversion rate of the ERC115 token created in the **liquidity pool** itself is also set in a similar fashion.
-
-### Liquidity Pool
-
-The engine keeps tracks of a set of canonical liquidity pool smart contracts, where market makers may deposit liquidity
-to be used for vaults, and indicate at what callstrike and putstrike ranges their liquidity may be used for.
-
-Liquidity pools are each their own deployed smart contract; one per collateral asset (this feature is wip), one per cash asset (USDC, DAI, etc), per putstrike value (80%, 85%, etc), per vault length (1 month, 3 months, etc).
-
-Thus a theoretical set of liquidity pools may look like this:
-
-| Address | Asset | PutStrike | Vault Length |
-| --- | --- | ----------- | ----|
-| 0x12345678... | USDC | 80% | 1 month |
-| 0x12345678... | USDC | 80% | 3 months |
-| 0x12345678... | USDC | 85% | 1 month |
-| 0x12345678... | USDC | 85% | 3 months |
-| 0x12345678... | DAI | 80% | 1 month |
-| 0x12345678... | DAI | 80% | 3 months |
-| 0x12345678... | DAI | 85% | 1 month |
-| 0x12345678... | DAI | 85% | 3 months |
-
-Vaults can only be created by matching a user's request with available liquidity from a pool. 
-When this match occurs, liquidity is "locked" for the vault until the vault is finalized.
-
-#### Locking Liquidity via ERC1155
-
-When liquidity is locked in a pool, it is converted to a new ERC1155 token.
-This token can be exchanged for the underlying (adjusted) liquidity at vault finalization, but
-note that it will be worth a different amount than the original liquidity deposited, depending 
-on the vault outcome. It might even be worth zero!
+TODO: update

--- a/script/readme.md
+++ b/script/readme.md
@@ -75,7 +75,7 @@ For this local/dev environment, we don't need to set up all of Uniswap, Chainlin
 
  - [Mocked UniV3 Router](../test/utils//MockUniRouter.sol)  - extremely simple mock of the Uniswap V3 router implementing only the `exactInputSingle` method (which is what vaults currently use to swap from collateral to cash). It will always use the maximum allowable slippage, eg `amountOutMinimum` and the trade will always succeed for any value (assuming the router has enough tokens; it's preloaded with 1 million of each token in each of these scripts by default)
 
- - [Mock Engine](../test/utils/MockEngine.sol) - fully functional `CollarEngine`, but we add in two functions to set the current price of an asset (for opening vaults) and the historical price of an asset at some blocktime (for closing vaults). You can have a look at the [vault manager tests](../test/unit/CollarVaultManager.t.sol) to see more specifically how this can be used.
+ - [Mock Engine](../test/utils/MockConfigHub.sol) - fully functional `CollarEngine`, but we add in two functions to set the current price of an asset (for opening vaults) and the historical price of an asset at some blocktime (for closing vaults). You can have a look at the [vault manager tests](../test/unit/CollarVaultManager.t.sol) to see more specifically how this can be used.
 
 ## Contract ABIs
 

--- a/src/implementations/ConfigHub.sol
+++ b/src/implementations/ConfigHub.sol
@@ -7,23 +7,18 @@
 
 pragma solidity 0.8.22;
 
-import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { IPeripheryImmutableState } from
     "@uniswap/v3-periphery/contracts/interfaces/IPeripheryImmutableState.sol";
 // internal imports
-import { ICollarEngine } from "../interfaces/ICollarEngine.sol";
+import { IConfigHub } from "../interfaces/IConfigHub.sol";
 import { UniV3OracleLib } from "../libs/UniV3OracleLib.sol";
 import { IProviderPositionNFT } from "../interfaces/IProviderPositionNFT.sol";
 import { ICollarTakerNFT } from "../interfaces/ICollarTakerNFT.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "forge-std/console.sol";
 
-contract CollarEngine is Ownable, ICollarEngine {
-    // -- lib delcarations --
-    using EnumerableSet for EnumerableSet.AddressSet;
-    using EnumerableSet for EnumerableSet.UintSet;
-
+contract ConfigHub is Ownable, IConfigHub {
     // -- public state variables ---
 
     string public constant VERSION = "0.2.0";
@@ -52,7 +47,7 @@ contract CollarEngine is Ownable, ICollarEngine {
         univ3SwapRouter = _univ3SwapRouter;
     }
 
-    // ----- state-changing functions (see ICollarEngine for documentation) -----
+    // ----- state-changing functions (see IConfigHub for documentation) -----
 
     function setCollarTakerContractAuth(address contractAddress, bool enabled) external onlyOwner {
         isCollarTakerNFT[contractAddress] = enabled;
@@ -107,7 +102,7 @@ contract CollarEngine is Ownable, ICollarEngine {
         emit CashAssetSupportSet(cashAsset, enabled);
     }
 
-    // ----- view functions (see ICollarEngine for documentation) -----
+    // ----- view functions (see IConfigHub for documentation) -----
 
     // collar durations
 

--- a/src/interfaces/ICollarTakerNFT.sol
+++ b/src/interfaces/ICollarTakerNFT.sol
@@ -8,7 +8,7 @@
 pragma solidity 0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { CollarEngine } from "../implementations/CollarEngine.sol";
+import { ConfigHub } from "../implementations/ConfigHub.sol";
 import { ProviderPositionNFT } from "../ProviderPositionNFT.sol";
 
 interface ICollarTakerNFT {
@@ -63,7 +63,7 @@ interface ICollarTakerNFT {
     // immutables
     function cashAsset() external view returns (IERC20);
     function collateralAsset() external view returns (IERC20);
-    function engine() external view returns (CollarEngine);
+    function configHub() external view returns (ConfigHub);
     // state
     function getPosition(uint takerId) external view returns (TakerPosition memory);
     function nextPositionId() external view returns (uint);

--- a/src/interfaces/IConfigHub.sol
+++ b/src/interfaces/IConfigHub.sol
@@ -7,7 +7,7 @@
 
 pragma solidity 0.8.22;
 
-interface ICollarEngine {
+interface IConfigHub {
     // EVENTS
 
     // auth'd actions
@@ -30,14 +30,14 @@ interface ICollarEngine {
 
     // ltv
 
-    /// @notice Sets the LTV minimum and max values for the engine
+    /// @notice Sets the LTV minimum and max values for the configHub
     /// @param minLTV The new minimum LTV
     /// @param maxLTV The new maximum LTV
     function setLTVRange(uint minLTV, uint maxLTV) external;
 
     // collar durations
 
-    /// @notice Sets the minimum and maximum collar durations for the engine
+    /// @notice Sets the minimum and maximum collar durations for the configHub
     /// @param minDuration The new minimum collar duration
     /// @param maxDuration The new maximum collar duration
     function setCollarDurationRange(uint minDuration, uint maxDuration) external;

--- a/src/interfaces/ILoans.sol
+++ b/src/interfaces/ILoans.sol
@@ -8,7 +8,7 @@
 pragma solidity 0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { CollarEngine } from "../implementations/CollarEngine.sol";
+import { ConfigHub } from "../implementations/ConfigHub.sol";
 import { CollarTakerNFT } from "../CollarTakerNFT.sol";
 import { ProviderPositionNFT } from "../ProviderPositionNFT.sol";
 import { Rolls } from "../Rolls.sol";
@@ -59,7 +59,7 @@ interface ILoans {
     // immutables
     function cashAsset() external view returns (IERC20);
     function collateralAsset() external view returns (IERC20);
-    function engine() external view returns (CollarEngine);
+    function configHub() external view returns (ConfigHub);
     function takerNFT() external view returns (CollarTakerNFT);
     // state
     function getLoan(uint takerId) external view returns (Loan memory);

--- a/src/interfaces/IProviderPositionNFT.sol
+++ b/src/interfaces/IProviderPositionNFT.sol
@@ -8,7 +8,7 @@
 pragma solidity 0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { CollarEngine } from "../implementations/CollarEngine.sol";
+import { ConfigHub } from "../implementations/ConfigHub.sol";
 
 interface IProviderPositionNFT {
     struct LiquidityOffer {
@@ -64,7 +64,7 @@ interface IProviderPositionNFT {
     function collarTakerContract() external view returns (address);
     function cashAsset() external view returns (IERC20);
     function collateralAsset() external view returns (IERC20);
-    function engine() external view returns (CollarEngine);
+    function configHub() external view returns (ConfigHub);
     // state
     function nextOfferId() external view returns (uint);
     function nextPositionId() external view returns (uint);

--- a/test/integration/ArbitrumMainnet.t.sol
+++ b/test/integration/ArbitrumMainnet.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.18;
 
 import "forge-std/console.sol";
-import { ICollarEngine } from "../../src/interfaces/ICollarEngine.sol";
+import { IConfigHub } from "../../src/interfaces/IConfigHub.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { CollarIntegrationPriceManipulation } from "./utils/PriceManipulation.t.sol";

--- a/test/integration/utils/PriceManipulation.t.sol
+++ b/test/integration/utils/PriceManipulation.t.sol
@@ -9,7 +9,7 @@ pragma solidity 0.8.22;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { CollarEngine } from "../../../src/implementations/CollarEngine.sol";
+import { ConfigHub } from "../../../src/implementations/ConfigHub.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IV3SwapRouter } from "@uniswap/swap-router-contracts/contracts/interfaces/IV3SwapRouter.sol";
@@ -24,7 +24,7 @@ abstract contract CollarIntegrationPriceManipulation is CollarBaseIntegrationTes
     uint public constant PRICE_DEVIATION_TOLERANCE = 1000; // 10% in basis points
 
     function getCurrentAssetPrice() internal view returns (uint) {
-        address uniV3Factory = IPeripheryImmutableState(engine.univ3SwapRouter()).factory();
+        address uniV3Factory = IPeripheryImmutableState(configHub.univ3SwapRouter()).factory();
         return TestPriceOracle.getUnsafePrice(address(collateralAsset), address(cashAsset), uniV3Factory);
     }
 
@@ -94,8 +94,8 @@ abstract contract CollarIntegrationPriceManipulation is CollarBaseIntegrationTes
         });
 
         startHoax(whale);
-        IERC20(swapParams.tokenIn).forceApprove(engine.univ3SwapRouter(), amount);
-        IV3SwapRouter(payable(engine.univ3SwapRouter())).exactInputSingle(swapParams);
+        IERC20(swapParams.tokenIn).forceApprove(configHub.univ3SwapRouter(), amount);
+        IV3SwapRouter(payable(configHub.univ3SwapRouter())).exactInputSingle(swapParams);
         vm.stopPrank();
 
         currentPrice = getCurrentAssetPrice();

--- a/test/unit/Loans.admin.t.sol
+++ b/test/unit/Loans.admin.t.sol
@@ -97,7 +97,7 @@ contract LoansAdminTest is LoansTestBase {
 
         // Test revert when taker NFT doesn't match
         CollarTakerNFT invalidTakerNFT =
-            new CollarTakerNFT(owner, engine, cashAsset, collateralAsset, "InvalidTakerNFT", "INVTKR");
+            new CollarTakerNFT(owner, configHub, cashAsset, collateralAsset, "InvalidTakerNFT", "INVTKR");
         Rolls invalidTakerRolls = new Rolls(owner, invalidTakerNFT, cashAsset);
         vm.expectRevert("rolls taker NFT mismatch");
         loans.setRollsContract(invalidTakerRolls);

--- a/test/unit/Loans.basic.reverts.t.sol
+++ b/test/unit/Loans.basic.reverts.t.sol
@@ -26,7 +26,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
 
         // bad provider
         ProviderPositionNFT invalidProviderNFT = new ProviderPositionNFT(
-            owner, engine, cashAsset, collateralAsset, address(takerNFT), "InvalidProviderNFT", "INVPRV"
+            owner, configHub, cashAsset, collateralAsset, address(takerNFT), "InvalidProviderNFT", "INVPRV"
         );
         vm.expectRevert("unsupported provider contract");
         loans.createLoan(collateralAmount, minLoanAmount, minSwapCash, invalidProviderNFT, 0);

--- a/test/unit/Loans.rolls.effects.t.sol
+++ b/test/unit/Loans.rolls.effects.t.sol
@@ -63,7 +63,7 @@ contract LoansRollTestBase is LoansTestBase {
         expected = calculateRollAmounts(rollId, newPrice);
 
         // Update price
-        engine.setHistoricalAssetPrice(address(collateralAsset), block.timestamp, newPrice);
+        configHub.setHistoricalAssetPrice(address(collateralAsset), block.timestamp, newPrice);
 
         // Execute roll
         vm.startPrank(user1);

--- a/test/unit/Loans.rolls.reverts.t.sol
+++ b/test/unit/Loans.rolls.reverts.t.sol
@@ -137,7 +137,7 @@ contract LoansRollsRevertsTest is LoansRollTestBase {
         takerNFT.approve(address(loans), takerId);
         // Set price to ensure taker needs to pay
         uint lowPrice = twapPrice * 95 / 100;
-        engine.setHistoricalAssetPrice(address(collateralAsset), block.timestamp, lowPrice);
+        configHub.setHistoricalAssetPrice(address(collateralAsset), block.timestamp, lowPrice);
 
         // Calculate expected loan change
         (int loanChangePreview,,) = rolls.calculateTransferAmounts(rollId, lowPrice);
@@ -181,7 +181,7 @@ contract LoansRollsRevertsTest is LoansRollTestBase {
         vm.startPrank(user1);
         takerNFT.approve(address(loans), takerId);
         cashAsset.approve(address(loans), type(uint).max);
-        engine.setHistoricalAssetPrice(address(collateralAsset), block.timestamp, twapPrice);
+        configHub.setHistoricalAssetPrice(address(collateralAsset), block.timestamp, twapPrice);
         prepareSwapToCollateralAtTWAPPrice();
         loans.closeLoan(takerId, 0);
 

--- a/test/utils/MockConfigHub.sol
+++ b/test/utils/MockConfigHub.sol
@@ -7,17 +7,17 @@
 
 pragma solidity 0.8.22;
 
-import { CollarEngine } from "../../src/implementations/CollarEngine.sol";
+import { ConfigHub } from "../../src/implementations/ConfigHub.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-contract MockEngine is CollarEngine {
+contract MockConfigHub is ConfigHub {
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.UintSet;
 
     mapping(address => uint) public currentAssetPrices;
     mapping(address => mapping(uint => uint)) public historicalAssetPrices;
 
-    constructor(address _univ3SwapRouter) CollarEngine(_univ3SwapRouter) { }
+    constructor(address _univ3SwapRouter) ConfigHub(_univ3SwapRouter) { }
 
     function setHistoricalAssetPrice(address asset, uint timestamp, uint value) external {
         historicalAssetPrices[asset][timestamp] = value;


### PR DESCRIPTION
Engine was a misleading name since the contract holds configuration mainly. 

ConfigHub was chosen from the various options (other shortlisted ones being SystemSettings, ConfigRegistry) because:
- Clearly central and not per-contract. 
- Clearly a contract name and not a data structure.
- Cannot be confused with internal settings (e.g., if we have a setter `setConfigHub` is clearly setting a contract, but `setSystemSettings` can be misunderstood to set some internal settings).
- `configHub` is short enough for frequent usage in code to not have to be shortened (as opposed to e.g., `systemSettings` or `configRegistry`
- Can be shortened to just `config` as a local variable if needed