### PR TITLE
[Part 2] Internal review Oct - several renamings

### DIFF
--- a/devdocs/2024-oct-internal-review-3.md
+++ b/devdocs/2024-oct-internal-review-3.md
@@ -70,7 +70,7 @@
 - [ ] #low isSupportedCash/Collateral redundant because canOpen is sufficient and the methods are always used together + assets are immutable in all using contracts. increases potential for config issues, gas, and admin dos.
 - [ ] #low ownable2step has error prone transfer method (since `transferOwnership` is overridden but functionality is different), override to `nominateOwner`
 - [ ] #note docs are incomplete
-- [ ] #note naming: BIPS / percent in LTV
+- [x] #note naming: BIPS / percent in LTV
 - [ ] #note MAX_CONFIGURABLE_DURATION 5 years seems excessive?
 
 ### Rolls

--- a/devdocs/2024-oct-internal-review-3.md
+++ b/devdocs/2024-oct-internal-review-3.md
@@ -40,7 +40,7 @@
 - [x] #note "unexpected takerId" check is redundant since checked value is returned from call invocation
 
 ### Taker
-- [x] #low putLocked / callLocked are bad names since aren't correct, should be takerLocker / makerLocked
+- [x] #low putLocked / callLocked are bad names since aren't correct, should be takerLocker / providerLocked
 - [ ] #low naming: collateralAsset should be "priceAsset", since collateral is ambiguous and is actually cash. Should be just address since not used as erc20.
 - [ ] #note Docs are incomplete
 - [x] #note previewSettlement arg position struct is awkward, should expect id
@@ -57,7 +57,7 @@
 - [ ] #low MAX_SWAP_TWAP_DEVIATION_BIPS is too low, and is a DoS risk => raise to 50%, since only for opens and is only a sanity check
 - [x] #low check canOpen for self and dependencies contracts
 - [ ] #low deadline for all offer specifying txs to prevent abuse of stale txs with current*. This is only relevant for congested networks though so not sure makes sense for arbi.
-- [x] #note naming: setKeeperAllowed should be setAllowsClosingKeeper
+- [x] #note naming: setKeeperApproved and keeperApproved
 - [x] #note naming: open instead of create
 
 ### Base admin

--- a/devdocs/2024-oct-internal-review-3.md
+++ b/devdocs/2024-oct-internal-review-3.md
@@ -64,7 +64,7 @@
 - [ ] #low rescuing nfts is not handled: use another arg / function to rescue nfts 
 - [ ] #low ownable2step has error prone transfer method (since `transferOwnership` is overridden but functionality is different). override to `nominateOwner`
 - [ ] #note docs for BaseEmergencyAdmin and BaseNFT + why they need config hub
-- [ ] #note naming: EmergencyAdmin is role and not attribute. BaseHubControlled?
+- [x] #note naming: EmergencyAdmin is role and not attribute. BaseHubControlled?
 
 ###  ConfigHub:
 - [ ] #low isSupportedCash/Collateral redundant because canOpen is sufficient and the methods are always used together + assets are immutable in all using contracts. increases potential for config issues, gas, and admin dos.

--- a/devdocs/2024-oct-internal-review-3.md
+++ b/devdocs/2024-oct-internal-review-3.md
@@ -75,7 +75,7 @@
 
 ### Rolls
 - [x] #note create offer balance and allowance checks seem redundant since for spoofing can easily be passed by providing positive amount, and for mistake prevention only helps with temporary issues. Consider removing to reduce complexity.
-- [ ] #note naming: `rollFee*` stutter
+- [x] #note naming: `rollFee*` stutter
 - [ ] #note execute checks order can be more intuitive: access control move to top, rearrange other checks
 - [x] #note doc that `uint(-..)` reverts for int.min
 - [x] #note docs why canOpen is not used

--- a/devdocs/2024-oct-internal-review-3.md
+++ b/devdocs/2024-oct-internal-review-3.md
@@ -26,7 +26,7 @@
 
 ###  Provider
 - [ ] #med min take amount to prevent dusting / composability issues / griefing via fee issues / griefing via 0 user locked pos, may be non-negligible in case of low decimals + low gas fees
-- [ ] #low "ShortProviderNFT" is bad name, confusing and inaccurate. Should be "CollarProviderNFT"
+- [x] #low "ShortProviderNFT" is bad name, confusing and inaccurate. Should be "CollarProviderNFT"
 - [ ] #low naming: collateralAsset should be "priceAsset", since collateral is ambiguous and is actually cash. Should be just address since not used as erc20.
 - [ ] #low max allowed protocol fee APR in provider offer
 - [ ] #low rethink whether `cancelAndWithdraw` flow is not needed since taker is trusted anyway with settlement, so just settle call can be used (with 0 delta) and expiry check should be removed on provider side.
@@ -40,12 +40,12 @@
 - [x] #note "unexpected takerId" check is redundant since checked value is returned from call invocation
 
 ### Taker
-- [ ] #low putLocked / callLocked are bad names since aren't correct, should be takerLocker / makerLocked
+- [x] #low putLocked / callLocked are bad names since aren't correct, should be takerLocker / makerLocked
 - [ ] #low naming: collateralAsset should be "priceAsset", since collateral is ambiguous and is actually cash. Should be just address since not used as erc20.
 - [ ] #note Docs are incomplete
 - [x] #note previewSettlement arg position struct is awkward, should expect id
 - [x] #note 0 put range check unneeded in calculateProviderLocked
-- [ ] #note naming: deviation -> percent
+- [x] #note naming: deviation -> percent
 - [ ] #note no good reason for recipient in withdrawal method
 - [x] #note cei can be better in settle
 

--- a/devdocs/2024-oct-internal-review-3.md
+++ b/devdocs/2024-oct-internal-review-3.md
@@ -57,7 +57,7 @@
 - [ ] #low MAX_SWAP_TWAP_DEVIATION_BIPS is too low, and is a DoS risk => raise to 50%, since only for opens and is only a sanity check
 - [x] #low check canOpen for self and dependencies contracts
 - [ ] #low deadline for all offer specifying txs to prevent abuse of stale txs with current*. This is only relevant for congested networks though so not sure makes sense for arbi.
-- [ ] #note naming: setKeeperAllowed should be setAllowsClosingKeeper
+- [x] #note naming: setKeeperAllowed should be setAllowsClosingKeeper
 - [x] #note naming: open instead of create
 
 ### Base admin

--- a/devdocs/2024-oct-internal-review-3.md
+++ b/devdocs/2024-oct-internal-review-3.md
@@ -18,8 +18,9 @@
   - mitigation: doc expected erc20 behaviors + consider balance checks
 - [x] #low remove all unused interface methods
 - [ ] #low document for each contract what post-deployment setup is needed (in that contract and others)
-- [ ] #low license header + incorrect email + security contact
+- [ ] #low incorrect email + missing security contact
 - [x] #low refactor all simple math (min / max / etc) with OZ library
+- [x] #note copyright header
 - [x] #note unused imports in a few places
 - [x] #note several notes and nits from lightchaser https://gist.github.com/ChaseTheLight01/a66ec6b0599e1760f8512c42ec5f96ea
 - [x] #note memory structs should be preferred to storage when access is read-only (even though gas is slightly higher) for clarity
@@ -36,17 +37,20 @@
     - redundant checks in taker and maker
     - cannot cancel with delta if needed
     - more gas by having to approve and transfer provider NFT
-- [ ] #note no good reason for recipient in withdrawal method
+- [x] #note no good reason for recipient in withdrawal method
 - [x] #note "unexpected takerId" check is redundant since checked value is returned from call invocation
 
 ### Taker
 - [x] #low putLocked / callLocked are bad names since aren't correct, should be takerLocker / providerLocked
 - [x] #low naming: collateralAsset should be "underlying", since collateral is ambiguous and is actually cash. Should be just address since not used as erc20.
+- [x] #low expiration should be calculated and checked vs. provider position because is key parameter (to reduce coupling)
+- [x] #low not all oracle views are checked in _setOracle, use interface instead of contract, check all used views
 - [ ] #note Docs are incomplete
+- [x] #note timestamp casting is not necessarily safe (if duration is not checked by provider)
 - [x] #note previewSettlement arg position struct is awkward, should expect id
 - [x] #note 0 put range check unneeded in calculateProviderLocked
 - [x] #note naming: deviation -> percent
-- [ ] #note no good reason for recipient in withdrawal method
+- [x] #note no good reason for recipient in withdrawal method
 - [x] #note cei can be better in settle
 
 ###  Escrow
@@ -69,14 +73,18 @@
 ###  ConfigHub:
 - [ ] #low isSupportedCash/Collateral redundant because canOpen is sufficient and the methods are always used together + assets are immutable in all using contracts. increases potential for config issues, gas, and admin dos.
 - [ ] #low ownable2step has error prone transfer method (since `transferOwnership` is overridden but functionality is different), override to `nominateOwner`
+- [ ] #low pause guardians should be a mapping / set to avoid having to share pauser pkey between team members / owner multi-sig signers and bot
 - [ ] #note docs are incomplete
 - [x] #note naming: BIPS / percent in LTV
 - [ ] #note MAX_CONFIGURABLE_DURATION 5 years seems excessive?
 
 ### Rolls
+- [ ] #low taker has insufficent protection: needs deadline for congestion / stale transactions, max roll fee for direct fee control (since fee adjusts with price)
+- [ ] #note "active" state variable can be replaced by checking if contract owns provider NFT
+- [ ] #note provider deadline protection may be excessive, since can cancel stale offers, and has price limits, and requires approvals
 - [x] #note create offer balance and allowance checks seem redundant since for spoofing can easily be passed by providing positive amount, and for mistake prevention only helps with temporary issues. Consider removing to reduce complexity.
 - [x] #note naming: `rollFee*` stutter
-- [ ] #note execute checks order can be more intuitive: access control move to top, rearrange other checks
+- [x] #note execute checks order can be more intuitive: access control move to top, rearrange other checks
 - [x] #note doc that `uint(-..)` reverts for int.min
 - [x] #note docs why canOpen is not used
 - [x] #note offer min max price check too strict, can be equal
@@ -92,3 +100,4 @@
 - no refund of protocol fee for cancellations, e.g., in case of rolls. fee APR and roll frequency are assumed to be low, and rolls are assumed to be beneficial enough to users to be worth it. accepted as low risk economic issue.
 - loanNFT owner is pushed any collateral leftovers during foreclosure instead of pulling (so can be a contract that will not forward it to actual user, e.g., an NFT trading contract). accepted severity low: low likelihood, medium impact.
 - loans currentProviderNFT, currentEscrowNFT, and currentRolls are assumed to change infrequently, so a stale transaction in which an offer for a different contract was intended by user is expected to be unlikely: arbitrum is unlikely to keep pending stale transactions, admin is trusted not to abuse, offer is assumed to not coincide with another existing offer in case of mistake, and various slippage parameters are assumed to be sufficient to prevent malicious scenarios. accepted risk up to low severity.
+- because oracle uses 1e18 as token amount, underlying asset tokens with more than 18 decimals and/or very low prices may have low precision prices  

--- a/devdocs/2024-oct-internal-review-3.md
+++ b/devdocs/2024-oct-internal-review-3.md
@@ -27,7 +27,7 @@
 ###  Provider
 - [ ] #med min take amount to prevent dusting / composability issues / griefing via fee issues / griefing via 0 user locked pos, may be non-negligible in case of low decimals + low gas fees
 - [x] #low "ShortProviderNFT" is bad name, confusing and inaccurate. Should be "CollarProviderNFT"
-- [ ] #low naming: collateralAsset should be "priceAsset", since collateral is ambiguous and is actually cash. Should be just address since not used as erc20.
+- [x] #low naming: collateralAsset should be "underlying", since collateral is ambiguous and is actually cash. Should be just address since not used as erc20.
 - [ ] #low max allowed protocol fee APR in provider offer
 - [ ] #low rethink whether `cancelAndWithdraw` flow is not needed since taker is trusted anyway with settlement, so just settle call can be used (with 0 delta) and expiry check should be removed on provider side.
   - pros of separate flows: ensures ownership of NFT and concent, ensures expiry invariant
@@ -41,7 +41,7 @@
 
 ### Taker
 - [x] #low putLocked / callLocked are bad names since aren't correct, should be takerLocker / providerLocked
-- [ ] #low naming: collateralAsset should be "priceAsset", since collateral is ambiguous and is actually cash. Should be just address since not used as erc20.
+- [x] #low naming: collateralAsset should be "underlying", since collateral is ambiguous and is actually cash. Should be just address since not used as erc20.
 - [ ] #note Docs are incomplete
 - [x] #note previewSettlement arg position struct is awkward, should expect id
 - [x] #note 0 put range check unneeded in calculateProviderLocked

--- a/script/arbitrum-mainnet/deploy-contracts.s.sol
+++ b/script/arbitrum-mainnet/deploy-contracts.s.sol
@@ -45,12 +45,12 @@ contract DeployContractsArbitrumMainnet is
         (address deployer,,,) = setup();
         vm.startBroadcast(deployer);
         ConfigHub configHub = deployConfigHub(deployer);
-        address[] memory collateralAssets = new address[](5);
-        collateralAssets[0] = WETH;
-        collateralAssets[1] = WBTC;
-        collateralAssets[2] = MATIC;
-        collateralAssets[3] = weETH;
-        collateralAssets[4] = stETH;
+        address[] memory underlyings = new address[](5);
+        underlyings[0] = WETH;
+        underlyings[1] = WBTC;
+        underlyings[2] = MATIC;
+        underlyings[3] = weETH;
+        underlyings[4] = stETH;
         address[] memory cashAssets = new address[](3);
         cashAssets[0] = USDC;
         cashAssets[1] = USDT;
@@ -65,7 +65,7 @@ contract DeployContractsArbitrumMainnet is
             configHub,
             SetupHelper.HubParams({
                 cashAssets: cashAssets,
-                collateralAssets: collateralAssets,
+                underlyings: underlyings,
                 minLTV: minLTV,
                 maxLTV: maxLTV,
                 minDuration: minDuration,
@@ -100,7 +100,7 @@ contract DeployContractsArbitrumMainnet is
             durations: allDurations,
             ltvs: allLTVs,
             cashAsset: IERC20(USDC),
-            collateralAsset: IERC20(WETH),
+            underlying: IERC20(WETH),
             oracleFeeTier: oracleFeeTier,
             swapFeeTier: swapFeeTier,
             twapWindow: twapWindow,
@@ -113,7 +113,7 @@ contract DeployContractsArbitrumMainnet is
             durations: singleDuration,
             ltvs: singleLTV,
             cashAsset: IERC20(USDT),
-            collateralAsset: IERC20(WETH),
+            underlying: IERC20(WETH),
             oracleFeeTier: oracleFeeTier,
             swapFeeTier: swapFeeTier,
             twapWindow: twapWindow,
@@ -127,7 +127,7 @@ contract DeployContractsArbitrumMainnet is
             durations: singleDuration,
             ltvs: singleLTV,
             cashAsset: IERC20(USDC),
-            collateralAsset: IERC20(WBTC),
+            underlying: IERC20(WBTC),
             oracleFeeTier: oracleFeeTier,
             swapFeeTier: swapFeeTier,
             twapWindow: twapWindow,
@@ -141,7 +141,7 @@ contract DeployContractsArbitrumMainnet is
         //     durations: singleDuration,
         //     ltvs: singleLTV,
         //     cashAsset: IERC20(USDC),
-        //     collateralAsset: IERC20(MATIC),
+        //     underlying: IERC20(MATIC),
         //     oracleFeeTier: oracleFeeTier,
         //     swapFeeTier: swapFeeTier,
         //     twapWindow: twapWindow,
@@ -155,7 +155,7 @@ contract DeployContractsArbitrumMainnet is
         //     durations: singleDuration,
         //     ltvs: singleLTV,
         //     cashAsset: IERC20(USDC),
-        //     collateralAsset: IERC20(stETH),
+        //     underlying: IERC20(stETH),
         //     oracleFeeTier: oracleFeeTier,
         //     swapFeeTier: swapFeeTier,
         //     twapWindow: twapWindow,
@@ -169,7 +169,7 @@ contract DeployContractsArbitrumMainnet is
         //     durations: singleDuration,
         //     ltvs: singleLTV,
         //     cashAsset: IERC20(WETH),
-        //     collateralAsset: IERC20(weETH),
+        //     underlying: IERC20(weETH),
         //     oracleFeeTier: oracleFeeTier,
         //     swapFeeTier: swapFeeTier,
         //     twapWindow: twapWindow,

--- a/script/arbitrum-mainnet/deploy-contracts.s.sol
+++ b/script/arbitrum-mainnet/deploy-contracts.s.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.22;
 import "forge-std/Script.sol";
 import "forge-std/console.sol";
 import { ConfigHub } from "../../src/ConfigHub.sol";
-import { ShortProviderNFT } from "../../src/ShortProviderNFT.sol";
+import { CollarProviderNFT } from "../../src/CollarProviderNFT.sol";
 import { CollarTakerNFT } from "../../src/CollarTakerNFT.sol";
 import { LoansNFT } from "../../src/LoansNFT.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/script/arbitrum-sepolia/deploy-contracts.s.sol
+++ b/script/arbitrum-sepolia/deploy-contracts.s.sol
@@ -42,7 +42,7 @@ contract DeployContractsArbitrumSepolia is
 
     // Set these to non-zero addresses if you want to use existing tokens
     address public cashAssetAddress = address(0x5D01F1E59C188a2A9Afc376cF6627dd5F28DC28F);
-    address public collateralAssetAddress = address(0x9A6E1a5f94De0aD8ca15b55eA0d39bEaEc579434);
+    address public underlyingAddress = address(0x9A6E1a5f94De0aD8ca15b55eA0d39bEaEc579434);
 
     function run() external {
         require(chainId == block.chainid, "chainId does not match the chainId in config");
@@ -52,10 +52,10 @@ contract DeployContractsArbitrumSepolia is
 
         ConfigHub configHub = deployConfigHub(deployer);
 
-        (cashAssetAddress, collateralAssetAddress) = _setupAssets();
+        (cashAssetAddress, underlyingAddress) = _setupAssets();
 
-        address[] memory collateralAssets = new address[](1);
-        collateralAssets[0] = collateralAssetAddress;
+        address[] memory underlyings = new address[](1);
+        underlyings[0] = underlyingAddress;
         address[] memory cashAssets = new address[](1);
         cashAssets[0] = cashAssetAddress;
 
@@ -63,7 +63,7 @@ contract DeployContractsArbitrumSepolia is
             configHub,
             HubParams({
                 cashAssets: cashAssets,
-                collateralAssets: collateralAssets,
+                underlyings: underlyings,
                 minLTV: ltv,
                 maxLTV: ltv,
                 minDuration: duration,
@@ -71,7 +71,7 @@ contract DeployContractsArbitrumSepolia is
             })
         );
 
-        _setupUniswapPool(cashAssetAddress, collateralAssetAddress);
+        _setupUniswapPool(cashAssetAddress, underlyingAddress);
 
         uint[] memory durations = new uint[](1);
         durations[0] = duration;
@@ -85,7 +85,7 @@ contract DeployContractsArbitrumSepolia is
             durations: durations,
             ltvs: ltvs,
             cashAsset: IERC20(cashAssetAddress),
-            collateralAsset: IERC20(collateralAssetAddress),
+            underlying: IERC20(underlyingAddress),
             oracleFeeTier: oracleFeeTier,
             swapFeeTier: swapFeeTier,
             twapWindow: twapWindow,
@@ -110,34 +110,34 @@ contract DeployContractsArbitrumSepolia is
         console.log("\nDeployment completed successfully");
     }
 
-    function _setupAssets() internal returns (address cash, address collateral) {
-        if (cashAssetAddress == address(0) || collateralAssetAddress == address(0)) {
+    function _setupAssets() internal returns (address cash, address underlying) {
+        if (cashAssetAddress == address(0) || underlyingAddress == address(0)) {
             console.log("Deploying new token contracts");
-            (cash, collateral) = deployTokens();
+            (cash, underlying) = deployTokens();
             console.log("Deployed Cash Asset: ", cash);
-            console.log("Deployed Collateral Asset: ", collateral);
+            console.log("Deployed Underlying Asset: ", underlying);
         } else {
             console.log("Using existing token contracts");
             cash = cashAssetAddress;
-            collateral = collateralAssetAddress;
+            underlying = underlyingAddress;
             console.log("Cash Asset: ", cash);
-            console.log("Collateral Asset: ", collateral);
+            console.log("Underlying Asset: ", underlying);
         }
     }
 
-    function _setupUniswapPool(address cashAsset, address collateralAsset)
+    function _setupUniswapPool(address cashAsset, address underlying)
         internal
         returns (address poolAddress)
     {
         IUniswapV3Factory factory =
             IUniswapV3Factory(IPeripheryImmutableState(address(SWAP_ROUTER)).factory());
-        poolAddress = factory.getPool(cashAsset, collateralAsset, 3000);
+        poolAddress = factory.getPool(cashAsset, underlying, 3000);
 
         if (poolAddress == address(0)) {
             console.log("Creating new Uniswap V3 pool");
             PoolParams memory params = PoolParams({
                 token1: cashAsset,
-                token2: collateralAsset,
+                token2: underlying,
                 router: address(SWAP_ROUTER),
                 positionManager: address(POSITION_MANAGER),
                 feeTier: 3000,

--- a/script/arbitrum-sepolia/deploy-contracts.s.sol
+++ b/script/arbitrum-sepolia/deploy-contracts.s.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.22;
 import "forge-std/Script.sol";
 import "forge-std/console.sol";
 import { ConfigHub } from "../../src/ConfigHub.sol";
-import { ShortProviderNFT } from "../../src/ShortProviderNFT.sol";
+import { CollarProviderNFT } from "../../src/CollarProviderNFT.sol";
 import { CollarTakerNFT } from "../../src/CollarTakerNFT.sol";
 import { LoansNFT } from "../../src/LoansNFT.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/script/deployment-helper.sol
+++ b/script/deployment-helper.sol
@@ -19,7 +19,7 @@ contract DeploymentHelper {
         LoansNFT loansContract;
         Rolls rollsContract;
         IERC20 cashAsset;
-        IERC20 collateralAsset;
+        IERC20 underlying;
         OracleUniV3TWAP oracle;
         SwapperUniV3 swapperUniV3;
         uint24 oracleFeeTier;
@@ -31,7 +31,7 @@ contract DeploymentHelper {
     struct PairConfig {
         string name;
         IERC20 cashAsset;
-        IERC20 collateralAsset;
+        IERC20 underlying;
         uint[] durations;
         uint[] ltvs;
         uint24 oracleFeeTier;
@@ -49,7 +49,7 @@ contract DeploymentHelper {
         returns (AssetPairContracts memory contracts)
     {
         OracleUniV3TWAP oracle = new OracleUniV3TWAP(
-            address(pairConfig.collateralAsset),
+            address(pairConfig.underlying),
             address(pairConfig.cashAsset),
             pairConfig.oracleFeeTier,
             pairConfig.twapWindow,
@@ -60,7 +60,7 @@ contract DeploymentHelper {
             owner,
             configHub,
             pairConfig.cashAsset,
-            pairConfig.collateralAsset,
+            pairConfig.underlying,
             oracle,
             string(abi.encodePacked("Taker ", pairConfig.name)),
             string(abi.encodePacked("T", pairConfig.name))
@@ -69,7 +69,7 @@ contract DeploymentHelper {
             owner,
             configHub,
             pairConfig.cashAsset,
-            pairConfig.collateralAsset,
+            pairConfig.underlying,
             address(takerNFT),
             string(abi.encodePacked("Provider ", pairConfig.name)),
             string(abi.encodePacked("P", pairConfig.name))
@@ -89,7 +89,7 @@ contract DeploymentHelper {
             loansContract: loansContract,
             rollsContract: rollsContract,
             cashAsset: pairConfig.cashAsset,
-            collateralAsset: pairConfig.collateralAsset,
+            underlying: pairConfig.underlying,
             oracle: oracle,
             swapperUniV3: swapperUniV3,
             oracleFeeTier: pairConfig.oracleFeeTier,

--- a/script/deployment-helper.sol
+++ b/script/deployment-helper.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.22;
 import "forge-std/console.sol";
 
 import { ConfigHub } from "../src/ConfigHub.sol";
-import { ShortProviderNFT } from "../src/ShortProviderNFT.sol";
+import { CollarProviderNFT } from "../src/CollarProviderNFT.sol";
 import { CollarTakerNFT } from "../src/CollarTakerNFT.sol";
 import { LoansNFT } from "../src/LoansNFT.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -14,7 +14,7 @@ import { SwapperUniV3 } from "../src/SwapperUniV3.sol";
 
 contract DeploymentHelper {
     struct AssetPairContracts {
-        ShortProviderNFT providerNFT;
+        CollarProviderNFT providerNFT;
         CollarTakerNFT takerNFT;
         LoansNFT loansContract;
         Rolls rollsContract;
@@ -65,7 +65,7 @@ contract DeploymentHelper {
             string(abi.encodePacked("Taker ", pairConfig.name)),
             string(abi.encodePacked("T", pairConfig.name))
         );
-        ShortProviderNFT providerNFT = new ShortProviderNFT(
+        CollarProviderNFT providerNFT = new CollarProviderNFT(
             owner,
             configHub,
             pairConfig.cashAsset,

--- a/script/setup-helper.sol
+++ b/script/setup-helper.sol
@@ -11,7 +11,7 @@ import { DeploymentHelper } from "./deployment-helper.sol";
 contract SetupHelper {
     struct HubParams {
         address[] cashAssets;
-        address[] collateralAssets;
+        address[] underlyings;
         uint minLTV;
         uint maxLTV;
         uint minDuration;
@@ -30,8 +30,8 @@ contract SetupHelper {
         for (uint i = 0; i < hubParams.cashAssets.length; i++) {
             configHub.setCashAssetSupport(hubParams.cashAssets[i], true);
         }
-        for (uint i = 0; i < hubParams.collateralAssets.length; i++) {
-            configHub.setCollateralAssetSupport(hubParams.collateralAssets[i], true);
+        for (uint i = 0; i < hubParams.underlyings.length; i++) {
+            configHub.setUnderlyingSupport(hubParams.underlyings[i], true);
         }
         configHub.setLTVRange(hubParams.minLTV, hubParams.maxLTV);
         configHub.setCollarDurationRange(hubParams.minDuration, hubParams.maxDuration);

--- a/script/utils/deployment-exporter.s.sol
+++ b/script/utils/deployment-exporter.s.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.22;
 
 import "forge-std/Script.sol";
-import { ShortProviderNFT } from "../../src/ShortProviderNFT.sol";
+import { CollarProviderNFT } from "../../src/CollarProviderNFT.sol";
 import { CollarTakerNFT } from "../../src/CollarTakerNFT.sol";
 import { LoansNFT } from "../../src/LoansNFT.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -195,7 +195,7 @@ contract DeploymentUtils is Script {
                 string memory baseKey = substring(allKeys[i], 0, bytes(allKeys[i]).length - 9);
 
                 result[resultIndex] = DeploymentHelper.AssetPairContracts({
-                    providerNFT: ShortProviderNFT(
+                    providerNFT: CollarProviderNFT(
                         _parseAddress(parsedJson, string(abi.encodePacked(".", baseKey, "_providerNFT")))
                     ),
                     takerNFT: CollarTakerNFT(

--- a/script/utils/deployment-exporter.s.sol
+++ b/script/utils/deployment-exporter.s.sol
@@ -36,7 +36,7 @@ contract DeploymentUtils is Script {
             DeploymentHelper.AssetPairContracts memory pair = assetPairs[i];
             string memory pairName = string(
                 abi.encodePacked(
-                    vm.toString(address(pair.collateralAsset)), "_", vm.toString(address(pair.cashAsset))
+                    vm.toString(address(pair.underlying)), "_", vm.toString(address(pair.cashAsset))
                 )
             );
 
@@ -79,12 +79,7 @@ contract DeploymentUtils is Script {
 
             json = string(
                 abi.encodePacked(
-                    json,
-                    '"',
-                    pairName,
-                    '_collateralAsset": "',
-                    vm.toString(address(pair.collateralAsset)),
-                    '",'
+                    json, '"', pairName, '_underlying": "', vm.toString(address(pair.underlying)), '",'
                 )
             );
 
@@ -210,8 +205,8 @@ contract DeploymentUtils is Script {
                     cashAsset: IERC20(
                         _parseAddress(parsedJson, string(abi.encodePacked(".", baseKey, "_cashAsset")))
                     ),
-                    collateralAsset: IERC20(
-                        _parseAddress(parsedJson, string(abi.encodePacked(".", baseKey, "_collateralAsset")))
+                    underlying: IERC20(
+                        _parseAddress(parsedJson, string(abi.encodePacked(".", baseKey, "_underlying")))
                     ),
                     oracle: OracleUniV3TWAP(
                         _parseAddress(parsedJson, string(abi.encodePacked(".", baseKey, "_oracle")))
@@ -235,17 +230,15 @@ contract DeploymentUtils is Script {
         return (configHubAddress, result);
     }
 
-    function getByAssetPair(address cashAsset, address collateralAsset)
+    function getByAssetPair(address cashAsset, address underlying)
         public
         view
         returns (address hub, DeploymentHelper.AssetPairContracts memory)
     {
         (address configHub, DeploymentHelper.AssetPairContracts[] memory allPairs) = getAll();
         for (uint i = 0; i < allPairs.length; i++) {
-            if (
-                address(allPairs[i].cashAsset) == cashAsset
-                    && address(allPairs[i].collateralAsset) == collateralAsset
-            ) {
+            if (address(allPairs[i].cashAsset) == cashAsset && address(allPairs[i].underlying) == underlying)
+            {
                 return (configHub, allPairs[i]);
             }
         }

--- a/src/CollarProviderNFT.sol
+++ b/src/CollarProviderNFT.sol
@@ -53,7 +53,7 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
 
     // ----- IMMUTABLES ----- //
     IERC20 public immutable cashAsset;
-    IERC20 public immutable collateralAsset; // only used for validation
+    address public immutable collateralAsset; // not used as ERC20 here
     // the trusted CollarTakerNFT contract. no interface is assumed because calls are only inbound
     address public immutable taker;
 
@@ -75,7 +75,7 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
         string memory _symbol
     ) BaseNFT(initialOwner, _name, _symbol) {
         cashAsset = _cashAsset;
-        collateralAsset = _collateralAsset;
+        collateralAsset = address(_collateralAsset);
         taker = _taker;
         _setConfigHub(_configHub);
         emit CollarProviderNFTCreated(address(_cashAsset), address(_collateralAsset), _taker);
@@ -342,7 +342,7 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
     function _configHubValidations(uint putStrikePercent, uint duration) internal view {
         // assets
         require(configHub.isSupportedCashAsset(address(cashAsset)), "unsupported asset");
-        require(configHub.isSupportedCollateralAsset(address(collateralAsset)), "unsupported asset");
+        require(configHub.isSupportedCollateralAsset(collateralAsset), "unsupported asset");
         // terms
         uint ltv = putStrikePercent; // assumed to be always equal
         require(configHub.isValidLTV(ltv), "unsupported LTV");

--- a/src/CollarProviderNFT.sol
+++ b/src/CollarProviderNFT.sol
@@ -11,10 +11,10 @@ import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/Saf
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { BaseNFT, ConfigHub } from "./base/BaseNFT.sol";
-import { IShortProviderNFT } from "./interfaces/IShortProviderNFT.sol";
+import { ICollarProviderNFT } from "./interfaces/ICollarProviderNFT.sol";
 
 /**
- * @title ShortProviderNFT
+ * @title CollarProviderNFT
  *
  * Main Functionality:
  * 1. Allows liquidity providers to create and manage offers for a specific Taker contract.
@@ -41,7 +41,7 @@ import { IShortProviderNFT } from "./interfaces/IShortProviderNFT.sol";
  * 1. Critical functions are only callable by the trusted taker contract.
  * 2. Offer and position parameters are validated against the configHub's configurations.
  */
-contract ShortProviderNFT is IShortProviderNFT, BaseNFT {
+contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
     using SafeERC20 for IERC20;
 
     uint internal constant BIPS_BASE = 10_000;
@@ -78,7 +78,7 @@ contract ShortProviderNFT is IShortProviderNFT, BaseNFT {
         collateralAsset = _collateralAsset;
         taker = _taker;
         _setConfigHub(_configHub);
-        emit ShortProviderNFTCreated(address(_cashAsset), address(_collateralAsset), _taker);
+        emit CollarProviderNFTCreated(address(_cashAsset), address(_collateralAsset), _taker);
     }
 
     modifier onlyTaker() {

--- a/src/CollarProviderNFT.sol
+++ b/src/CollarProviderNFT.sol
@@ -53,7 +53,7 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
 
     // ----- IMMUTABLES ----- //
     IERC20 public immutable cashAsset;
-    address public immutable collateralAsset; // not used as ERC20 here
+    address public immutable underlying; // not used as ERC20 here
     // the trusted CollarTakerNFT contract. no interface is assumed because calls are only inbound
     address public immutable taker;
 
@@ -69,16 +69,16 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
         address initialOwner,
         ConfigHub _configHub,
         IERC20 _cashAsset,
-        IERC20 _collateralAsset,
+        IERC20 _underlying,
         address _taker,
         string memory _name,
         string memory _symbol
     ) BaseNFT(initialOwner, _name, _symbol) {
         cashAsset = _cashAsset;
-        collateralAsset = address(_collateralAsset);
+        underlying = address(_underlying);
         taker = _taker;
         _setConfigHub(_configHub);
-        emit CollarProviderNFTCreated(address(_cashAsset), address(_collateralAsset), _taker);
+        emit CollarProviderNFTCreated(address(_cashAsset), address(_underlying), _taker);
     }
 
     modifier onlyTaker() {
@@ -342,7 +342,7 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
     function _configHubValidations(uint putStrikePercent, uint duration) internal view {
         // assets
         require(configHub.isSupportedCashAsset(address(cashAsset)), "unsupported asset");
-        require(configHub.isSupportedCollateralAsset(collateralAsset), "unsupported asset");
+        require(configHub.isSupportedUnderlying(underlying), "unsupported asset");
         // terms
         uint ltv = putStrikePercent; // assumed to be always equal
         require(configHub.isValidLTV(ltv), "unsupported LTV");

--- a/src/CollarProviderNFT.sol
+++ b/src/CollarProviderNFT.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
 import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -34,8 +28,8 @@ import { ICollarProviderNFT } from "./interfaces/ICollarProviderNFT.sol";
  * 2. The associated taker contract is trusted and properly implemented.
  * 3. The ConfigHub contract correctly manages protocol parameters and authorization.
  * 4. Put strike percent is assumed to always equal the Loan-to-Value (LTV) ratio.
- * 5. Asset (ERC-20) contracts are simple, non rebasing, do not allow reentrancy, and transfers
- *    work as expected.
+ * 5. Asset (ERC-20) contracts are simple, non rebasing, do not allow reentrancy, balance changes
+ *    correspond to transfer arguments.
  *
  * Security Notes:
  * 1. Critical functions are only callable by the trusted taker contract.
@@ -190,12 +184,11 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
     /// @param amount The amount of cash asset to use for the new position
     /// @param takerId The ID of the taker position for which this position is minted
     /// @return positionId The ID of the newly created position (NFT token ID)
-    /// @return position The details of the newly created position
     function mintFromOffer(uint offerId, uint amount, uint takerId)
         external
         whenNotPaused
         onlyTaker
-        returns (uint positionId, ProviderPosition memory position)
+        returns (uint positionId)
     {
         // @dev only checked on open, not checked later on settle / cancel to allow withdraw-only mode
         require(configHub.canOpen(msg.sender), "unsupported taker contract");
@@ -216,7 +209,7 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
         // storage updates
         offer.available = prevOfferAmount - amount - fee;
         positionId = nextTokenId++;
-        position = ProviderPosition({
+        positions[positionId] = ProviderPosition({
             takerId: takerId,
             expiration: block.timestamp + offer.duration,
             principal: amount,
@@ -225,12 +218,11 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
             settled: false,
             withdrawable: 0
         });
-        positions[positionId] = position;
 
         emit OfferUpdated(offerId, msg.sender, prevOfferAmount, offer.available);
 
         // emit creation before transfer. No need to emit takerId, because it's emitted by the taker event
-        emit PositionCreated(positionId, offerId, fee, position);
+        emit PositionCreated(positionId, offerId, fee, positions[positionId]);
 
         // mint the NFT to the provider
         // @dev does not use _safeMint to avoid reentrancy
@@ -264,7 +256,7 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
         require(block.timestamp >= position.expiration, "not expired");
 
         require(!position.settled, "already settled");
-        position.settled = true; // done here as this also acts as partial-reentrancy protection
+        position.settled = true; // done here as CEI
 
         uint initial = position.principal;
         if (cashDelta > 0) {
@@ -284,55 +276,53 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
         emit PositionSettled(positionId, cashDelta, position.withdrawable);
     }
 
-    /// @notice Cancels a position and withdraws the principal to a recipient. Burns the NFT.
+    /// @notice Cancels a position and withdraws the principal to current owner. Burns the NFT.
     /// Can ONLY be called through the taker contract, which MUST be the owner of NFT
-    /// when the call is made (so will have received it from the concenting provider), and is trusted
+    /// when the call is made (so will have received it from the consenting provider), and is trusted
     /// to cancel the other side of the position.
     /// @dev note that a withdrawal is triggerred (and the NFT is burned) because in contrast
     /// to settlement, during cancellation the caller MUST be the NFT owner (is the provider),
     /// so is assumed to specify the withdrawal correctly for their funds.
     /// @param positionId The ID of the position to cancel (NFT token ID)
-    /// @param recipient The address to receive the withdrawn funds
-    function cancelAndWithdraw(uint positionId, address recipient) external whenNotPaused onlyTaker {
+    function cancelAndWithdraw(uint positionId) external whenNotPaused onlyTaker returns (uint withdrawal) {
         // caller is BOTH taker contract, and NFT owner
         require(msg.sender == ownerOf(positionId), "caller does not own token");
 
         ProviderPosition storage position = positions[positionId];
-
         require(!position.settled, "already settled");
-        position.settled = true; // done here as this also acts as reentrancy protection
 
-        uint withdrawal = position.principal;
+        // store changes
+        position.settled = true; // done here as CEI
 
         // burn token
         _burn(positionId);
 
-        cashAsset.safeTransfer(recipient, withdrawal);
+        withdrawal = position.principal;
+        cashAsset.safeTransfer(msg.sender, withdrawal);
 
-        emit PositionCanceled(positionId, recipient, withdrawal, position.expiration);
+        emit PositionCanceled(positionId, withdrawal, position.expiration);
     }
 
     // ----- actions by position owner ----- //
 
     /// @notice Withdraws funds from a settled position. Can only be called for a settled position
-    /// (and not a cancelled one), and checks the ownernship of the NFT. Burns the NFT.
+    /// (and not a cancelled one), and checks the ownership of the NFT. Burns the NFT.
     /// @param positionId The ID of the settled position to withdraw from (NFT token ID).
-    /// @param recipient The address to receive the withdrawn funds
-    function withdrawFromSettled(uint positionId, address recipient) external whenNotPaused {
+    function withdrawFromSettled(uint positionId) external whenNotPaused returns (uint withdrawal) {
         require(msg.sender == ownerOf(positionId), "not position owner");
 
         ProviderPosition storage position = positions[positionId];
         require(position.settled, "not settled");
 
-        uint withdrawable = position.withdrawable;
+        withdrawal = position.withdrawable;
         // zero out withdrawable
         position.withdrawable = 0;
         // burn token
         _burn(positionId);
         // transfer tokens
-        cashAsset.safeTransfer(recipient, withdrawable);
+        cashAsset.safeTransfer(msg.sender, withdrawal);
 
-        emit WithdrawalFromSettled(positionId, recipient, withdrawable);
+        emit WithdrawalFromSettled(positionId, withdrawal);
     }
 
     // ----- INTERNAL MUTATIVE ----- //

--- a/src/CollarTakerNFT.sol
+++ b/src/CollarTakerNFT.sol
@@ -23,7 +23,7 @@ contract CollarTakerNFT is ICollarTakerNFT, BaseNFT {
 
     // ----- IMMUTABLES ----- //
     IERC20 public immutable cashAsset;
-    IERC20 public immutable collateralAsset;
+    address public immutable collateralAsset; // not used as ERC20 here
 
     // ----- STATE VARIABLES ----- //
     OracleUniV3TWAP public oracle;
@@ -39,7 +39,7 @@ contract CollarTakerNFT is ICollarTakerNFT, BaseNFT {
         string memory _symbol
     ) BaseNFT(initialOwner, _name, _symbol) {
         cashAsset = _cashAsset;
-        collateralAsset = _collateralAsset;
+        collateralAsset = address(_collateralAsset);
         _setConfigHub(_configHub);
         _setOracle(_oracle);
         emit CollarTakerNFTCreated(address(_cashAsset), address(_collateralAsset), address(_oracle));
@@ -97,7 +97,7 @@ contract CollarTakerNFT is ICollarTakerNFT, BaseNFT {
     ) external whenNotPaused returns (uint takerId, uint providerId) {
         // check assets allowed
         require(configHub.isSupportedCashAsset(address(cashAsset)), "unsupported asset");
-        require(configHub.isSupportedCollateralAsset(address(collateralAsset)), "unsupported asset");
+        require(configHub.isSupportedCollateralAsset(collateralAsset), "unsupported asset");
         // check self allowed
         require(configHub.canOpen(address(this)), "unsupported taker contract");
         // check provider allowed
@@ -256,7 +256,7 @@ contract CollarTakerNFT is ICollarTakerNFT, BaseNFT {
     // internal owner
 
     function _setOracle(OracleUniV3TWAP _oracle) internal {
-        require(_oracle.baseToken() == address(collateralAsset), "oracle asset mismatch");
+        require(_oracle.baseToken() == collateralAsset, "oracle asset mismatch");
         require(_oracle.quoteToken() == address(cashAsset), "oracle asset mismatch");
         // Ensure doesn't revert and returns a price at least right now.
         // Only a sanity check, since this doesn't ensure that it will work in the future,

--- a/src/ConfigHub.sol
+++ b/src/ConfigHub.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
 import { Ownable2Step, Ownable } from "@openzeppelin/contracts/access/Ownable2Step.sol";

--- a/src/ConfigHub.sol
+++ b/src/ConfigHub.sol
@@ -32,7 +32,7 @@ contract ConfigHub is Ownable2Step, IConfigHub {
     address public pauseGuardian;
     address public feeRecipient;
 
-    mapping(address collateralAssetAddress => bool isSupported) public isSupportedCollateralAsset;
+    mapping(address unlderlyingAddress => bool isSupported) public isSupportedUnderlying;
     mapping(address cashAssetAddress => bool isSupported) public isSupportedCashAsset;
     /// @notice internal contracts auth, "canOpen" means different things within different contracts.
     /// "closing" already opened is allowed (unless paused).
@@ -76,12 +76,12 @@ contract ConfigHub is Ownable2Step, IConfigHub {
         emit CollarDurationRangeSet(min, max);
     }
 
-    /// @notice Sets whether a particular collateral asset is supported
-    /// @param collateralAsset The address of the collateral asset
+    /// @notice Sets whether a particular underlying asset is supported
+    /// @param underlying The address of the underlying asset
     /// @param enabled Whether the asset is supported
-    function setCollateralAssetSupport(address collateralAsset, bool enabled) external onlyOwner {
-        isSupportedCollateralAsset[collateralAsset] = enabled;
-        emit CollateralAssetSupportSet(collateralAsset, enabled);
+    function setUnderlyingSupport(address underlying, bool enabled) external onlyOwner {
+        isSupportedUnderlying[underlying] = enabled;
+        emit UnderlyingSupportSet(underlying, enabled);
     }
 
     /// @notice Sets whether a particular cash asset is supported

--- a/src/ConfigHub.sol
+++ b/src/ConfigHub.sol
@@ -17,8 +17,8 @@ contract ConfigHub is Ownable2Step, IConfigHub {
     string public constant VERSION = "0.2.0";
 
     // configuration validation (validate on set)
-    uint public constant MIN_CONFIGURABLE_LTV = BIPS_BASE / 10; // 10%
-    uint public constant MAX_CONFIGURABLE_LTV = BIPS_BASE - 1; // avoid 0 range edge cases
+    uint public constant MIN_CONFIGURABLE_LTV_BIPS = BIPS_BASE / 10; // 10%
+    uint public constant MAX_CONFIGURABLE_LTV_BIPS = BIPS_BASE - 1; // avoid 0 range edge cases
     uint public constant MIN_CONFIGURABLE_DURATION = 300; // 5 minutes
     uint public constant MAX_CONFIGURABLE_DURATION = 5 * 365 days; // 5 years
 
@@ -56,8 +56,8 @@ contract ConfigHub is Ownable2Step, IConfigHub {
     /// @param min The new minimum LTV
     /// @param max The new maximum LTV
     function setLTVRange(uint min, uint max) external onlyOwner {
-        require(min >= MIN_CONFIGURABLE_LTV, "min too low");
-        require(max <= MAX_CONFIGURABLE_LTV, "max too high");
+        require(min >= MIN_CONFIGURABLE_LTV_BIPS, "min too low");
+        require(max <= MAX_CONFIGURABLE_LTV_BIPS, "max too high");
         require(min <= max, "min > max");
         minLTV = min;
         maxLTV = max;

--- a/src/EscrowSupplierNFT.sol
+++ b/src/EscrowSupplierNFT.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -33,8 +27,8 @@ import { IEscrowSupplierNFT } from "./interfaces/IEscrowSupplierNFT.sol";
  * 1. Escrow suppliers must be able to receive ERC-721 tokens to withdraw offers or earnings.
  * 2. The associated Loans contracts are trusted and properly implemented.
  * 3. The ConfigHub contract correctly manages protocol parameters and authorization.
- * 4. Asset (ERC-20) contracts are simple (non rebasing) and do not allow reentrancy.
- *
+ * 4. Asset (ERC-20) contracts are simple (non rebasing), do not allow reentrancy, balance changes from
+ *    transfer arguments.
  * Design Considerations:
  * 1. Uses NFTs to represent escrow positions, allowing for secondary market usage.
  * 2. Implements pausability and asset recovery for emergency situations via BaseNFT.

--- a/src/EscrowSupplierNFT.sol
+++ b/src/EscrowSupplierNFT.sol
@@ -290,7 +290,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
      * @notice Switches an escrow to a new escrow.
      * @dev While it is basically startEscrow + endEscrow, calling these methods externally
      * is not possible because startEscrow pulls the escrow amount in and transfers it out,
-     * which is not possible when switching escrows (the loans contract has no collateral for
+     * which is not possible when switching escrows (the loans contract has no underlying for
      * such a transfer at that point). So instead this method is needed to "move" funds internally.
      * @dev Can only be called by the Loans contract that started the original escrow
      * @dev durations can be different (is not problematic within this contract),
@@ -538,7 +538,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
     }
 
     function _configHubValidations(uint duration) internal view {
-        require(configHub.isSupportedCollateralAsset(address(asset)), "unsupported asset");
+        require(configHub.isSupportedUnderlying(address(asset)), "unsupported asset");
         require(configHub.isValidCollarDuration(duration), "unsupported duration");
     }
 }

--- a/src/LoansNFT.sol
+++ b/src/LoansNFT.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
 import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -604,7 +598,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
 
         /// @dev this should not be optional, since otherwise there is no point to the entire call
         /// (and the position NFT would be burned already, so would not belong to sender)
-        withdrawnAmount = takerNFT.withdrawFromSettled(takerId, address(this));
+        withdrawnAmount = takerNFT.withdrawFromSettled(takerId);
     }
 
     function _executeRoll(uint loanId, uint rollId, int minToUser)
@@ -623,7 +617,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         // get transfer amount and fee from rolls
         int transferPreview;
         (transferPreview,, rollFee) =
-            currentRolls.calculateTransferAmounts(rollId, takerNFT.currentOraclePrice());
+            currentRolls.previewTransferAmounts(rollId, takerNFT.currentOraclePrice());
 
         // pull cash
         if (transferPreview < 0) {

--- a/src/LoansNFT.sol
+++ b/src/LoansNFT.sol
@@ -65,7 +65,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
     // swap back during loan closing
     address public closingKeeper;
     // callers (users or escrow owners) that allow a keeper for loan closing
-    mapping(address sender => bool enabled) public allowsClosingKeeper;
+    mapping(address sender => bool enabled) public keeperApproved;
     // the currently configured & allowed rolls contract for this takerNFT and cash asset
     Rolls public currentRolls;
     // the currently configured provider contract for opening (may change)
@@ -387,9 +387,9 @@ contract LoansNFT is ILoansNFT, BaseNFT {
      * that should be valid when closeLoan is called by the keeper.
      * @param enabled True to allow the keeper, false to disallow
      */
-    function setKeeperAllowed(bool enabled) external whenNotPaused {
-        allowsClosingKeeper[msg.sender] = enabled;
-        emit ClosingKeeperAllowed(msg.sender, enabled);
+    function setKeeperApproved(bool enabled) external whenNotPaused {
+        keeperApproved[msg.sender] = enabled;
+        emit ClosingKeeperApproved(msg.sender, enabled);
     }
 
     // ----- Admin methods ----- //
@@ -795,8 +795,8 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         bool isSender = msg.sender == authorizedSender; // is the auth target
         bool isKeeper = msg.sender == closingKeeper;
         // our auth target allows the keeper
-        bool keeperAllowed = allowsClosingKeeper[authorizedSender];
-        return isSender || (keeperAllowed && isKeeper);
+        bool _keeperApproved = keeperApproved[authorizedSender];
+        return isSender || (_keeperApproved && isKeeper);
     }
 
     function _newLoanIdCheck(uint takerId) internal view returns (uint loanId) {

--- a/src/LoansNFT.sol
+++ b/src/LoansNFT.sol
@@ -498,10 +498,10 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         // The only state reads before are owner-set state: pause and swapper allowlist.
         uint cashFromSwap = _swapCollateralWithTwapCheck(collateralAmount, swapParams);
 
-        uint putStrikeDeviation = currentProviderNFT.getOffer(offerId).putStrikeDeviation;
+        uint putStrikePercent = currentProviderNFT.getOffer(offerId).putStrikePercent;
 
         // this assumes LTV === put strike price
-        loanAmount = putStrikeDeviation * cashFromSwap / BIPS_BASE;
+        loanAmount = putStrikePercent * cashFromSwap / BIPS_BASE;
         // everything that remains is locked on the put side in the collar position
         uint takerLocked = cashFromSwap - loanAmount;
 

--- a/src/LoansNFT.sol
+++ b/src/LoansNFT.sol
@@ -82,7 +82,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
     {
         takerNFT = _takerNFT;
         cashAsset = _takerNFT.cashAsset();
-        collateralAsset = _takerNFT.collateralAsset();
+        collateralAsset = IERC20(_takerNFT.collateralAsset());
         _setConfigHub(_takerNFT.configHub());
     }
 

--- a/src/LoansNFT.sol
+++ b/src/LoansNFT.sol
@@ -503,13 +503,13 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         // this assumes LTV === put strike price
         loanAmount = putStrikeDeviation * cashFromSwap / BIPS_BASE;
         // everything that remains is locked on the put side in the collar position
-        uint putLockedCash = cashFromSwap - loanAmount;
+        uint takerLocked = cashFromSwap - loanAmount;
 
         // approve the taker contract
-        cashAsset.forceApprove(address(takerNFT), putLockedCash);
+        cashAsset.forceApprove(address(takerNFT), takerLocked);
 
         // stores, mints, calls providerNFT and mints there, emits the event
-        (takerId, providerId) = takerNFT.openPairedPosition(putLockedCash, currentProviderNFT, offerId);
+        (takerId, providerId) = takerNFT.openPairedPosition(takerLocked, currentProviderNFT, offerId);
     }
 
     function _swapCollateralWithTwapCheck(uint collateralAmount, SwapParams calldata swapParams)
@@ -519,7 +519,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         cashFromSwap = _swap(collateralAsset, cashAsset, collateralAmount, swapParams);
 
         // @dev note that TWAP price is used for payout decision in CollarTakerNFT, and swap price
-        // only affects the putLockedCash passed into it - so does not affect the provider, only the user
+        // only affects the takerLocked passed into it - so does not affect the provider, only the user
         _checkSwapPrice(cashFromSwap, collateralAmount);
     }
 

--- a/src/LoansNFT.sol
+++ b/src/LoansNFT.sol
@@ -18,20 +18,20 @@ import { ILoansNFT } from "./interfaces/ILoansNFT.sol";
 
 /**
  * @title LoansNFT
- * @dev This contract manages opening, closing, and rolling of collateralized loans via Collar positions,
+ * @dev This contract manages opening, closing, and rolling of loans via Collar positions,
  * with optional escrow support.
  *
  * Main Functionality:
- * 1. Allows users to open loans by providing collateral and borrowing against it, with or without escrow.
- * 2. Handles the swapping of collateral to the cash asset via allowed Swappers (that use dex routers).
+ * 1. Allows users to open loans by providing underlying and borrowing against it, with or without escrow.
+ * 2. Handles the swapping of underlying to the cash asset via allowed Swappers (that use dex routers).
  * 3. Wraps CollarTakerNFT (keeps it in the contract), and mints an NFT with loanId == takerId to the user.
- * 4. Manages loan closure, including repayment and swapping back to collateral.
+ * 4. Manages loan closure, including repayment and swapping back to underlying.
  * 5. Provides keeper functionality for automated loan closure and foreclosure to mitigate price fluctuation risks.
  * 6. Allows rolling (extending) the loan via an owner and user approved Rolls contract.
  * 7. Supports escrow functionality, including opening escrow loans, switching escrows during rolls, and foreclosure.
  *
  * Key Assumptions and Prerequisites:
- * 1. Allowed Swappers and the underlying dex routers / aggregators are trusted and properly implemented.
+ * 1. Allowed Swappers and the dex routers / aggregators they use are trusted and properly implemented.
  * 2. Depends on ConfigHub, CollarTakerNFT, CollarProviderNFT, EscrowSupplierNFT, Rolls, and their
  * dependencies (Oracle).
  * 3. Assets (ERC-20) used are standard compliant (non-rebasing, no transfer fees, no callbacks).
@@ -56,7 +56,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
     // ----- IMMUTABLES ----- //
     CollarTakerNFT public immutable takerNFT;
     IERC20 public immutable cashAsset;
-    IERC20 public immutable collateralAsset;
+    IERC20 public immutable underlying;
 
     // ----- STATE VARIABLES ----- //
     /// @notice Stores loan information for each NFT ID
@@ -82,7 +82,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
     {
         takerNFT = _takerNFT;
         cashAsset = _takerNFT.cashAsset();
-        collateralAsset = IERC20(_takerNFT.collateralAsset());
+        underlying = IERC20(_takerNFT.underlying());
         _setConfigHub(_takerNFT.configHub());
     }
 
@@ -115,15 +115,15 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         (uint cashAvailable,) = takerNFT.previewSettlement(_takerId(loanId), oraclePrice);
 
         // oracle price is for 1e18 tokens (regardless of decimals):
-        // oracle-price = collateral-price * 1e18, so price = oracle-price / 1e18,
-        // since collateral = cash / price, we get collateral = cash * 1e18 / oracle-price.
+        // oracle-price = underlying-price * 1e18, so price = oracle-price / 1e18,
+        // since underlying = cash / price, we get underlying = cash * 1e18 / oracle-price.
         // round down is ok since it's against the user (being foreclosed).
         // division by zero is not prevented because because a panic is ok with an invalid price
-        uint collateral = cashAvailable * takerNFT.oracle().BASE_TOKEN_AMOUNT() / oraclePrice;
+        uint underlyingAmount = cashAvailable * takerNFT.oracle().BASE_TOKEN_AMOUNT() / oraclePrice;
 
         Loan memory loan = loans[loanId];
-        // assume all available collateral can be used for fees (escrowNFT will cap between max and min)
-        uint gracePeriod = loan.escrowNFT.cappedGracePeriod(loan.escrowId, collateral);
+        // assume all available underlying can be used for fees (escrowNFT will cap between max and min)
+        uint gracePeriod = loan.escrowNFT.cappedGracePeriod(loan.escrowId, underlyingAmount);
         // always after expiration, also cappedGracePeriod() is at least min-grace-period
         return expiration + gracePeriod;
     }
@@ -133,16 +133,16 @@ contract LoansNFT is ILoansNFT, BaseNFT {
     // ----- User / Keeper methods ----- //
 
     /**
-     * @notice Opens a new loan by providing collateral and borrowing against it
-     *      1. Transfers collateral from the user to this contract
-     *      2. Swaps collateral for cash
+     * @notice Opens a new loan by providing underlying and borrowing against it
+     *      1. Transfers underlying from the user to this contract
+     *      2. Swaps underlying for cash
      *      3. Opens a loan position using the CollarTakerNFT contract
      *      4. Transfers the borrowed amount to the user
      *      5. Transfers the minted NFT to the user
-     * @param collateralAmount The amount of collateral asset to be provided
+     * @param underlyingAmount The amount of underlying asset to be provided
      * @param minLoanAmount The minimum acceptable loan amount (slippage protection)
      * @param swapParams SwapParams struct with:
-     *     - The minimum acceptable amount of cash from the collateral swap (slippage protection)
+     *     - The minimum acceptable amount of cash from the underlying swap (slippage protection)
      *     - an allowed Swapper
      *     - any extraData the swapper needs to use
      * @param providerOffer The ID of the liquidity offer to use from the provider
@@ -151,26 +151,26 @@ contract LoansNFT is ILoansNFT, BaseNFT {
      * @return loanAmount The actual amount of the loan opened in cash asset
      */
     function openLoan(
-        uint collateralAmount,
+        uint underlyingAmount,
         uint minLoanAmount,
         SwapParams calldata swapParams,
         uint providerOffer
     ) public whenNotPaused returns (uint loanId, uint providerId, uint loanAmount) {
-        return _openLoan(collateralAmount, minLoanAmount, swapParams, providerOffer, false, 0);
+        return _openLoan(underlyingAmount, minLoanAmount, swapParams, providerOffer, false, 0);
     }
 
     /**
-     * @notice Opens a new escrow-type loan by providing collateral and borrowing against it
-     *      1. Transfers collateral from the user to this contract
-     *      2. Uses the escrow contract to deposit user's callateral, and take supplier's collateral
-     *      3. Swaps collateral for cash
+     * @notice Opens a new escrow-type loan by providing underlying and borrowing against it
+     *      1. Transfers underlying from the user to this contract
+     *      2. Uses the escrow contract to deposit user's underlying, and take supplier's underlying
+     *      3. Swaps underlying for cash
      *      4. Opens a loan position using the CollarTakerNFT contract
      *      5. Transfers the borrowed amount to the user
      *      6. Transfers the minted NFT to the user
-     * @param collateralAmount The amount of collateral asset to be provided
+     * @param underlyingAmount The amount of underlying asset to be provided
      * @param minLoanAmount The minimum acceptable loan amount (slippage protection)
      * @param swapParams SwapParams struct with:
-     *     - The minimum acceptable amount of cash from the collateral swap (slippage protection)
+     *     - The minimum acceptable amount of cash from the underlying swap (slippage protection)
      *     - an allowed Swapper
      *     - any extraData the swapper needs to use
      * @param providerOffer The ID of the liquidity offer to use from the provider
@@ -180,20 +180,20 @@ contract LoansNFT is ILoansNFT, BaseNFT {
      * @return loanAmount The actual amount of the loan opened in cash asset
      */
     function openEscrowLoan(
-        uint collateralAmount,
+        uint underlyingAmount,
         uint minLoanAmount,
         SwapParams calldata swapParams,
         uint providerOffer,
         uint escrowOffer
     ) external whenNotPaused returns (uint loanId, uint providerId, uint loanAmount) {
-        return _openLoan(collateralAmount, minLoanAmount, swapParams, providerOffer, true, escrowOffer);
+        return _openLoan(underlyingAmount, minLoanAmount, swapParams, providerOffer, true, escrowOffer);
     }
 
     /**
-     * @notice Closes an existing loan, repaying the borrowed amount and returning collateral.
-     * If escrow was used, releases it by returning the swapped collateral in exchange for the user's collateral
+     * @notice Closes an existing loan, repaying the borrowed amount and returning underlying.
+     * If escrow was used, releases it by returning the swapped underlying in exchange for the user's underlying
      * handling any late fees.
-     * The amount of collateral returned may be smaller or larger than originally deposited,
+     * The amount of underlying returned may be smaller or larger than originally deposited,
      * depending on the position's settlement result, fees, and the final swap.
      * This method can be called by either the loan's owner (the CollarTakerNFT owner) or by a keeper
      * if the keeper was allowed by the current owner (by calling setKeeperAllowed). Using a keeper
@@ -206,21 +206,21 @@ contract LoansNFT is ILoansNFT, BaseNFT {
      *      1. Transfers the repayment amount from the user to this contract
      *      2. Settles the CollarTakerNFT position
      *      3. Withdraws any available funds from the settled position
-     *      4. Swaps the total cash amount back to collateral asset
+     *      4. Swaps the total cash amount back to underlying asset
      *      5. Releases the escrow if needed
-     *      6. Transfers the collateral back to the user
+     *      6. Transfers the underlying back to the user
      *      7. Burns the NFT
      * @param loanId The ID of the CollarTakerNFT representing the loan to close
      * @param swapParams SwapParams struct with:
-     *     - The minimum acceptable amount of collateral to receive (slippage protection)
+     *     - The minimum acceptable amount of underlying to receive (slippage protection)
      *     - an allowed Swapper
      *     - any extraData the swapper needs to use
-     * @return collateralOut The actual amount of collateral asset returned to the user
+     * @return underlyingOut The actual amount of underlying asset returned to the user
      */
     function closeLoan(uint loanId, SwapParams calldata swapParams)
         external
         whenNotPaused // also checked in _burn (mutations false positive)
-        returns (uint collateralOut)
+        returns (uint underlyingOut)
     {
         /// @dev will also revert on non-existent (unminted / burned) loan ID
         require(_isSenderOrKeeperFor(ownerOf(loanId)), "not NFT owner or allowed keeper");
@@ -230,20 +230,20 @@ contract LoansNFT is ILoansNFT, BaseNFT {
 
         uint fromSwap = _closeLoanNoTFOut(loanId, swapParams);
 
-        collateralOut = _conditionalReleaseEscrow(loanId, fromSwap);
+        underlyingOut = _conditionalReleaseEscrow(loanId, fromSwap);
 
-        collateralAsset.safeTransfer(user, collateralOut);
+        underlying.safeTransfer(user, underlyingOut);
     }
 
     /**
      * @notice Rolls an existing loan to a new taker position with updated terms via a Rolls contract.
      * The loan amount is updated according to the funds transferred (excluding the roll-fee), and the
-     * collateral is unchanged.
+     * underlying is unchanged.
      * If the loan uses escrow, the previous escrow is switched for a new escrow, the new fee is pulled
      * from the user, and any refund for the previous escrow fee is sent to the user.
      * @dev The user must have approved this contract prior to calling:
      *      - Cash asset for potential repayment (if needed according for Roll execution)
-     *      - Collateral asset for new escrow fee (if the original loan used escrow)
+     *      - Underlying asset for new escrow fee (if the original loan used escrow)
      * @param loanId The ID of the NFT representing the loan to be rolled
      * @param rollId The ID of the roll offer to be executed
      * @param minToUser The minimum acceptable transfer to user (negative if expecting to pay)
@@ -283,7 +283,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         newLoanId = _newLoanIdCheck(newTakerId);
         // store the new loan data
         loans[newLoanId] = Loan({
-            collateralAmount: prevLoan.collateralAmount,
+            underlyingAmount: prevLoan.underlyingAmount,
             loanAmount: newLoanAmount,
             usesEscrow: prevLoan.usesEscrow,
             escrowNFT: prevLoan.escrowNFT,
@@ -325,7 +325,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
      * is dynamically limited by the position's cash, to minimize late-fee underpayment.
      * @dev Can be called only by the escrow owner or an allowed keeper (if authorized by escrow owner)
      * @param loanId The ID of the loan to foreclose
-     * @param swapParams Swap parameters for cash to collateral conversion
+     * @param swapParams Swap parameters for cash to underlying conversion
      */
     function forecloseLoan(uint loanId, SwapParams calldata swapParams) external whenNotPaused {
         Loan memory loan = loans[loanId];
@@ -367,13 +367,13 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         uint cashAvailable = _settleAndWithdrawTaker(loanId);
 
         // @dev Reentrancy assumption: no user state writes or reads AFTER the swapper call in _swap.
-        uint fromSwap = _swap(cashAsset, collateralAsset, cashAvailable, swapParams);
+        uint fromSwap = _swap(cashAsset, underlying, cashAvailable, swapParams);
 
         // Release escrow, and send any leftovers to user. Their express trigger of balance update
         // (withdrawal) is neglected here due to being anyway in an undesirable state of being foreclosed
         // due to not repaying on time.
         uint toUser = _releaseEscrow(escrowNFT, escrowId, fromSwap);
-        collateralAsset.safeTransfer(user, toUser);
+        underlying.safeTransfer(user, toUser);
 
         emit LoanForeclosed(loanId, escrowId, fromSwap, toUser);
     }
@@ -413,7 +413,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
             address(providerNFT) == UNSET || providerNFT.taker() == address(takerNFT),
             "provider taker mismatch"
         );
-        require(address(escrowNFT) == UNSET || escrowNFT.asset() == collateralAsset, "escrow asset mismatch");
+        require(address(escrowNFT) == UNSET || escrowNFT.asset() == underlying, "escrow asset mismatch");
         currentRolls = rolls;
         currentProviderNFT = providerNFT;
         currentEscrowNFT = escrowNFT;
@@ -438,7 +438,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
 
     /// @dev handles both escrow and non-escrow loans
     function _openLoan(
-        uint collateralAmount,
+        uint underlyingAmount,
         uint minLoanAmount,
         SwapParams calldata swapParams,
         uint providerOffer,
@@ -451,21 +451,21 @@ contract LoansNFT is ILoansNFT, BaseNFT {
 
         // @dev in additional to this, escrow interest fee may also be pulled in _conditionalOpenEscrow
         // So approval needs to be for this + interest fee
-        collateralAsset.safeTransferFrom(msg.sender, address(this), collateralAmount);
+        underlying.safeTransferFrom(msg.sender, address(this), underlyingAmount);
 
-        // handle optional escrow, must be done first, to use "supplier's" collateral in swap
+        // handle optional escrow, must be done first, to use "supplier's" underlying in swap
         (EscrowSupplierNFT escrowNFT, uint escrowId) =
-            _conditionalOpenEscrow(usesEscrow, collateralAmount, escrowOffer);
+            _conditionalOpenEscrow(usesEscrow, underlyingAmount, escrowOffer);
 
         // @dev Reentrancy assumption: no user state writes or reads BEFORE this call
         uint takerId;
-        (takerId, providerId, loanAmount) = _swapAndMintCollar(collateralAmount, providerOffer, swapParams);
+        (takerId, providerId, loanAmount) = _swapAndMintCollar(underlyingAmount, providerOffer, swapParams);
         require(loanAmount >= minLoanAmount, "loan amount too low");
 
         loanId = _newLoanIdCheck(takerId);
         // store the loan opening data
         loans[loanId] = Loan({
-            collateralAmount: collateralAmount,
+            underlyingAmount: underlyingAmount,
             loanAmount: loanAmount,
             usesEscrow: usesEscrow,
             escrowNFT: escrowNFT, // save the escrow used
@@ -479,24 +479,24 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         // transfer the full loan amount on open
         cashAsset.safeTransfer(msg.sender, loanAmount);
 
-        emit LoanOpened(loanId, msg.sender, providerOffer, collateralAmount, loanAmount);
+        emit LoanOpened(loanId, msg.sender, providerOffer, underlyingAmount, loanAmount);
     }
 
-    /// @dev swaps collateral to cash and mints collar position
-    function _swapAndMintCollar(uint collateralAmount, uint offerId, SwapParams calldata swapParams)
+    /// @dev swaps underlying to cash and mints collar position
+    function _swapAndMintCollar(uint underlyingAmount, uint offerId, SwapParams calldata swapParams)
         internal
         returns (uint takerId, uint providerId, uint loanAmount)
     {
         require(configHub.canOpen(address(takerNFT)), "unsupported taker contract");
         // provider contract is valid
         require(address(currentProviderNFT) != UNSET, "provider contract unset");
-        // 0 collateral is later checked to mean non-existing loan, also prevents div-zero
-        require(collateralAmount != 0, "invalid collateral amount");
+        // 0 underlying is later checked to mean non-existing loan, also prevents div-zero
+        require(underlyingAmount != 0, "invalid underlying amount");
 
-        // swap collateral
+        // swap underlying
         // @dev Reentrancy assumption: no user state writes or reads BEFORE the swapper call in _swap.
         // The only state reads before are owner-set state: pause and swapper allowlist.
-        uint cashFromSwap = _swapCollateralWithTwapCheck(collateralAmount, swapParams);
+        uint cashFromSwap = _swapUnderlyingWithTwapCheck(underlyingAmount, swapParams);
 
         uint putStrikePercent = currentProviderNFT.getOffer(offerId).putStrikePercent;
 
@@ -512,15 +512,15 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         (takerId, providerId) = takerNFT.openPairedPosition(takerLocked, currentProviderNFT, offerId);
     }
 
-    function _swapCollateralWithTwapCheck(uint collateralAmount, SwapParams calldata swapParams)
+    function _swapUnderlyingWithTwapCheck(uint underlyingAmount, SwapParams calldata swapParams)
         internal
         returns (uint cashFromSwap)
     {
-        cashFromSwap = _swap(collateralAsset, cashAsset, collateralAmount, swapParams);
+        cashFromSwap = _swap(underlying, cashAsset, underlyingAmount, swapParams);
 
         // @dev note that TWAP price is used for payout decision in CollarTakerNFT, and swap price
         // only affects the takerLocked passed into it - so does not affect the provider, only the user
-        _checkSwapPrice(cashFromSwap, collateralAmount);
+        _checkSwapPrice(cashFromSwap, underlyingAmount);
     }
 
     /// @dev swap logic with balance and slippage checks
@@ -561,10 +561,10 @@ contract LoansNFT is ILoansNFT, BaseNFT {
 
     /// @dev loan closure logic without final transfer
     /// @dev access control (loanId owner ot their keeper) is expected to be checked by caller
-    /// @dev this method DOES NOT transfer the swapped collateral to user
+    /// @dev this method DOES NOT transfer the swapped underlying to user
     function _closeLoanNoTFOut(uint loanId, SwapParams calldata swapParams)
         internal
-        returns (uint collateralOut)
+        returns (uint underlyingOut)
     {
         // @dev user is the NFT owner, since msg.sender can be a keeper
         // If called by keeper, the user must trust it because:
@@ -587,9 +587,9 @@ contract LoansNFT is ILoansNFT, BaseNFT {
 
         // @dev Reentrancy assumption: no user state writes or reads AFTER the swapper call in _swap.
         uint cashAmount = loanAmount + takerWithdrawal;
-        collateralOut = _swap(cashAsset, collateralAsset, cashAmount, swapParams);
+        underlyingOut = _swap(cashAsset, underlying, cashAmount, swapParams);
 
-        emit LoanClosed(loanId, msg.sender, user, loanAmount, cashAmount, collateralOut);
+        emit LoanClosed(loanId, msg.sender, user, loanAmount, cashAmount, underlyingOut);
     }
 
     function _settleAndWithdrawTaker(uint loanId) internal returns (uint withdrawnAmount) {
@@ -669,8 +669,8 @@ contract LoansNFT is ILoansNFT, BaseNFT {
             require(configHub.canOpen(address(escrowNFT)), "unsupported escrow contract");
 
             uint fee = _pullEscrowFee(escrowNFT, escrowOffer, escrowed);
-            // @dev collateralAmount was pulled already before calling this method
-            collateralAsset.forceApprove(address(escrowNFT), escrowed + fee);
+            // @dev underlyingAmount was pulled already before calling this method
+            underlying.forceApprove(address(escrowNFT), escrowed + fee);
             (escrowId,) = escrowNFT.startEscrow({
                 offerId: escrowOffer,
                 escrowed: escrowed,
@@ -692,8 +692,8 @@ contract LoansNFT is ILoansNFT, BaseNFT {
             // check this escrow is still allowed
             require(configHub.canOpen(address(prevLoan.escrowNFT)), "unsupported escrow contract");
 
-            uint newFee = _pullEscrowFee(prevLoan.escrowNFT, escrowOffer, prevLoan.collateralAmount);
-            collateralAsset.forceApprove(address(prevLoan.escrowNFT), newFee);
+            uint newFee = _pullEscrowFee(prevLoan.escrowNFT, escrowOffer, prevLoan.underlyingAmount);
+            underlying.forceApprove(address(prevLoan.escrowNFT), newFee);
             // rotate escrows
             uint feeRefund;
             (newEscrowId,, feeRefund) = prevLoan.escrowNFT.switchEscrow({
@@ -704,7 +704,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
             });
 
             // send potential interest fee refund
-            collateralAsset.safeTransfer(msg.sender, feeRefund);
+            underlying.safeTransfer(msg.sender, feeRefund);
         } else {
             // returns default empty value
         }
@@ -717,20 +717,20 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         // calc and pull the interest fee to be paid upfront
         interestFee = escrowNFT.interestFee(escrowOffer, escrowed);
         // explicit approval check here to provide clearer error since fee amount is not provided by user
-        uint allowance = collateralAsset.allowance(msg.sender, address(this));
+        uint allowance = underlying.allowance(msg.sender, address(this));
         require(allowance >= interestFee, "insufficient allowance for escrow fee");
-        collateralAsset.safeTransferFrom(msg.sender, address(this), interestFee);
+        underlying.safeTransferFrom(msg.sender, address(this), interestFee);
     }
 
-    function _conditionalReleaseEscrow(uint loanId, uint fromSwap) internal returns (uint collateralOut) {
+    function _conditionalReleaseEscrow(uint loanId, uint fromSwap) internal returns (uint underlyingOut) {
         Loan memory loan = loans[loanId];
-        // collateral is what's released by escrow, or return the full swap amount if escrow not used
+        // underlying is what's released by escrow, or return the full swap amount if escrow not used
         return loan.usesEscrow ? _releaseEscrow(loan.escrowNFT, loan.escrowId, fromSwap) : fromSwap;
     }
 
     function _releaseEscrow(EscrowSupplierNFT escrowNFT, uint escrowId, uint fromSwap)
         internal
-        returns (uint collateralOut)
+        returns (uint underlyingOut)
     {
         // get late fee owing
         (uint lateFee, uint escrowed) = escrowNFT.lateFees(escrowId);
@@ -741,7 +741,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         uint leftOver = fromSwap - toEscrow;
 
         // release from escrow, this can be smaller than available
-        collateralAsset.forceApprove(address(escrowNFT), toEscrow);
+        underlying.forceApprove(address(escrowNFT), toEscrow);
         // fromEscrow is what escrow returns after deducting any shortfall.
         // (although not problematic, there should not be any interest fee refund here,
         // because this method is called after expiry)
@@ -749,7 +749,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         // @dev no balance checks because contract holds no funds, mismatch will cause reverts
 
         // the released and the leftovers to be sent to user. Zero-value-transfer is allowed
-        collateralOut = fromEscrow + leftOver;
+        underlyingOut = fromEscrow + leftOver;
 
         emit EscrowSettled(escrowId, lateFee, toEscrow, fromEscrow, leftOver);
     }
@@ -784,7 +784,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
                 // @dev no balance checks because contract holds no funds, mismatch will cause reverts
 
                 // send potential interest fee refund
-                collateralAsset.safeTransfer(refundRecipient, toUser);
+                underlying.safeTransfer(refundRecipient, toUser);
             }
         }
     }
@@ -807,7 +807,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         // check that the ID is not yet taken. This should not be possible, since takerId should mint
         // new IDs correctly, but can be checked for completeness.
         // @dev non-zero should be ensured when opening loan
-        require(loans[loanId].collateralAmount == 0, "loanId taken");
+        require(loans[loanId].underlyingAmount == 0, "loanId taken");
     }
 
     function _takerId(uint loanId) internal pure returns (uint takerId) {
@@ -824,10 +824,10 @@ contract LoansNFT is ILoansNFT, BaseNFT {
     /// Due to this, price manipulation *should* NOT leak value from provider / protocol.
     /// The caller (user) is protected via a slippage parameter, and SHOULD use it to avoid MEV (if present).
     /// So, this check is just extra precaution and avoidance of extreme edge-cases.
-    function _checkSwapPrice(uint cashFromSwap, uint collateralAmount) internal view {
+    function _checkSwapPrice(uint cashFromSwap, uint underlyingAmount) internal view {
         uint twapPrice = takerNFT.currentOraclePrice();
-        // collateral is checked on open to not be 0
-        uint swapPrice = cashFromSwap * takerNFT.oracle().BASE_TOKEN_AMOUNT() / collateralAmount;
+        // underlying is checked on open to not be 0
+        uint swapPrice = cashFromSwap * takerNFT.oracle().BASE_TOKEN_AMOUNT() / underlyingAmount;
         uint diff = swapPrice > twapPrice ? swapPrice - twapPrice : twapPrice - swapPrice;
         uint deviation = diff * BIPS_BASE / twapPrice;
         require(deviation <= MAX_SWAP_TWAP_DEVIATION_BIPS, "swap and twap price too different");
@@ -840,7 +840,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
     {
         // The transfer subtracted the fee, so it needs to be added back. The fee is not part of
         // the loan so that if price hasn't changed, after rolling, the updated
-        // loan amount would still be equivalent to the initial collateral.
+        // loan amount would still be equivalent to the initial underlying.
         // Example: transfer = position-gain - fee = 100 - 1 = 99
         //      So: position-gain = transfer + fee = 99 + 1 = 100
         int loanChange = rollTransferIn + rollFee;

--- a/src/OracleUniV3TWAP.sol
+++ b/src/OracleUniV3TWAP.sol
@@ -1,16 +1,12 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
 import { IUniswapV3Factory } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol";
 import { OracleLibrary, IUniswapV3Pool } from "@uniswap/v3-periphery/contracts/libraries/OracleLibrary.sol";
 import { IPeripheryImmutableState } from
     "@uniswap/v3-periphery/contracts/interfaces/IPeripheryImmutableState.sol";
+
+import { ITakerOracle } from "./interfaces/ITakerOracle.sol";
 
 /// The warning below copied from Euler:
 ///     https://github.com/euler-xyz/euler-price-oracle/blob/95e5d325cd9f4290d147821ff08add14ca99b136/src/adapter/uniswap/UniswapV3Oracle.sol#L14-L22
@@ -23,7 +19,7 @@ import { IPeripheryImmutableState } from
 /// The chosen pool must have enough total liquidity and some full-range liquidity to resist manipulation.
 /// The chosen pool must have had sufficient liquidity when past observations were recorded in the buffer.
 /// Networks with short block times are highly susceptible to TWAP manipulation due to the reduced attack cost.
-contract OracleUniV3TWAP {
+contract OracleUniV3TWAP is ITakerOracle {
     uint128 public constant BASE_TOKEN_AMOUNT = 1e18;
     uint32 public constant MIN_TWAP_WINDOW = 300;
     string public constant VERSION = "0.2.0";

--- a/src/Rolls.sol
+++ b/src/Rolls.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
 import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -21,9 +15,9 @@ import { IRolls } from "./interfaces/IRolls.sol";
  * expiry.
  *
  * Main Functionality:
- * 1. Allows providers to create roll offers for existing positions.
- * 2. Handles the cancellation of created roll offers.
- * 3. Executes rolls, cancelling (settling) existing positions and creating new ones with updated terms.
+ * 1. Allows providers to create and cancel roll offers for existing positions.
+ * 2. Allows takers to execute rolls, cancelling existing collar positions and creating new ones
+ *    with updated terms.
  * 4. Manages the transfer of funds between takers and providers during rolls.
  *
  * Role in the Protocol:
@@ -31,18 +25,12 @@ import { IRolls } from "./interfaces/IRolls.sol";
  *
  * Key Assumptions and Prerequisites:
  * 1. The CollarTakerNFT and CollarProviderNFT contracts are correctly implemented and authorized.
- * 2. The cash asset (ERC-20) used is standard compliant (non-rebasing, no transfer fees, no callbacks).
+ * 2. The cash asset (ERC-20) used is simple (non-rebasing, no transfer fees, no callbacks).
  * 3. Providers must approve this contract to transfer their CollarProviderNFTs and cash when creating
  * an offer. The NFT is transferred on offer creation, and cash will be transferred on execution, if
- * and when the user accepts the offer.
+ * and when the taker accepts the offer.
  * 4. Takers must approve this contract to transfer their CollarTakerNFTs and any cash that's needed
  * to be pulled.
- *
- * Design Considerations:
- * 1. Offers are made by providers, and accepted (and executed) by takers.
- * 2. Implements pausability for emergency situations.
- * 3. Calculates fees based on price changes to allow correct fee pricing when asset price moves.
- * 4. Settles existing positions and creates new ones atomically to ensure consistency.
  *
  * Security Considerations:
  * 1. Does not hold cash (only during execution), but will have approvals to spend cash.
@@ -67,7 +55,7 @@ contract Rolls is IRolls, BaseManaged {
 
     mapping(uint rollId => RollOffer) internal rollOffers;
 
-    /// @dev Rolls needs BaseEmergencyAdmin for pausing since is approved by users, and holds NFTs.
+    /// @dev Rolls needs BaseManaged for pausing since is approved by users, and holds NFTs.
     /// Does not need `canOpen` auth because its auth usage is set directly on Loans,
     /// and it has no long-lived functionality so doesn't need a close-only migration mode.
     constructor(address initialOwner, CollarTakerNFT _takerNFT) BaseManaged(initialOwner) {
@@ -87,20 +75,20 @@ contract Rolls is IRolls, BaseManaged {
      * @notice Calculates the roll fee based on the price
      * @dev The fee changes based on the price change since the offer was created.
      * All three of - price change, roll fee, and delta-factor - can be negative. The fee is adjusted
-     * such that positive `price-change x delta-factor` increase the fee (provider benefits), and decrease
-     * the fee (taker benefits) if negative.
+     * such that positive `price-change x delta-factor` increases the fee (provider benefits),
+     * and negative decreases the fee (taker benefits).
      * 0 delta-factor means the fee is constant, 100% delta-factor (10_000 in bips), means the price
-     * linearly scales the fee (according to the sign logic)
+     * linearly scales the fee (according to the sign logic).
      * @param offer The roll offer to calculate the fee for
-     * @param currentPrice The current price to use for the calculation
-     * @return rollFee The calculated roll fee (in cash amount)
+     * @param price The price to use for the calculation, in ITakerOracle price units
+     * @return rollFee The calculated roll fee (in cash amount), positive if paid to provider
      */
-    function calculateRollFee(RollOffer memory offer, uint currentPrice) public pure returns (int rollFee) {
+    function calculateRollFee(RollOffer memory offer, uint price) public pure returns (int rollFee) {
         int prevPrice = offer.feeReferencePrice.toInt256();
-        int priceChange = currentPrice.toInt256() - prevPrice;
+        int priceChange = price.toInt256() - prevPrice;
         // Scaling the fee magnitude by the delta (price change) multiplied by the factor.
         // For deltaFactor of 100%, this results in linear scaling of the fee with price.
-        // If factor is BIPS_BASE the amount moves with the price. E.g., 5% price increase, 5% fee increase.
+        // So for BIPS_BASE the result moves with the price. E.g., 5% price increase, 5% fee increase.
         // If factor is, e.g., 50% the fee increases only 2.5% for a 5% price increase.
         int feeSize = SignedMath.abs(offer.feeAmount).toInt256();
         int change = feeSize * offer.feeDeltaFactorBIPS * priceChange / prevPrice / int(BIPS_BASE);
@@ -114,7 +102,7 @@ contract Rolls is IRolls, BaseManaged {
 
     /**
      * @notice Calculates the amounts to be transferred during a roll execution at a specific price.
-     * This does not check any of the execution validity conditions (deadline, price range, etc...).
+     * This does not check any validity conditions (existence, deadline, price range, etc...).
      * @dev If validity is important, a staticcall to the executeRoll method should be used instead of
      * this view.
      * @param rollId The ID of the roll offer
@@ -123,20 +111,14 @@ contract Rolls is IRolls, BaseManaged {
      * @return toProvider The amount that would be transferred to (or from, if negative) the provider
      * @return rollFee The roll fee that would be applied
      */
-    function calculateTransferAmounts(uint rollId, uint price)
+    function previewTransferAmounts(uint rollId, uint price)
         external
         view
         returns (int toTaker, int toProvider, int rollFee)
     {
         RollOffer memory offer = rollOffers[rollId];
-        CollarTakerNFT.TakerPosition memory takerPos = takerNFT.getPosition(offer.takerId);
         rollFee = calculateRollFee(offer, price);
-        (toTaker, toProvider) = _calculateTransferAmounts({
-            newPrice: price,
-            rollFeeAmount: rollFee,
-            takerId: offer.takerId,
-            providerPos: takerPos.providerNFT.getPosition(takerPos.providerId)
-        });
+        (toTaker, toProvider) = _previewTransferAmounts(offer.takerId, price, rollFee);
     }
 
     // ----- MUTATIVE FUNCTIONS ----- //
@@ -153,7 +135,7 @@ contract Rolls is IRolls, BaseManaged {
      * @param maxPrice The maximum acceptable price for roll execution
      * @param minToProvider The minimum amount the provider is willing to receive, or maximum willing to pay
      *     if negative. The execution transfer (in or out) will be checked to be >= this value.
-     * @param deadline The timestamp after which this offer can no longer be executed
+     * @param deadline The timestamp after which this offer can no longer be created or executed
      * @return rollId The ID of the newly created roll offer
      *
      * @dev if the provider will need to provide cash on execution, they must approve the contract to pull that
@@ -221,7 +203,7 @@ contract Rolls is IRolls, BaseManaged {
      */
     function cancelOffer(uint rollId) external whenNotPaused {
         RollOffer storage offer = rollOffers[rollId];
-        require(msg.sender == offer.provider, "not initial provider");
+        require(msg.sender == offer.provider, "not offer provider");
         require(offer.active, "offer not active");
         // cancel offer
         offer.active = false;
@@ -232,27 +214,34 @@ contract Rolls is IRolls, BaseManaged {
 
     /**
      * @notice Executes a roll, settling the existing paired position and creating a new one.
-     * This pulls and distributes cash, pulls taker NFT, and sends out new taker and provider NFTs.
+     * This pulls cash, pulls taker NFT, sends out new taker and provider NFTs, and pays cash.
      * @dev The caller must be the owner of the CollarTakerNFT for the position being rolled,
      * and must have approved sufficient cash if cash needs to be paid (depends on offer and current price)
      * @param rollId The ID of the roll offer to execute
      * @param minToTaker The minimum amount the user (taker) is willing to receive, or maximum willing to
-     *     pay if negative. The execution transfer (in or out) will be checked to be >= this value.
+     *     pay if negative. The transfer (in or out, signed int too) will be checked to be >= this value.
      * @return newTakerId The ID of the newly created CollarTakerNFT position
      * @return newProviderId The ID of the newly created CollarProviderNFT position
      * @return toTaker The amount transferred to (or from, if negative) the taker
      * @return toProvider The amount transferred to (or from, if negative) the provider
      */
-    function executeRoll(
-        uint rollId,
-        int minToTaker // signed "slippage", user protection
-    ) external whenNotPaused returns (uint newTakerId, uint newProviderId, int toTaker, int toProvider) {
-        RollOffer storage offer = rollOffers[rollId];
-        // offer was cancelled (if taken tokens would be burned)
+    function executeRoll(uint rollId, int minToTaker)
+        external
+        whenNotPaused
+        returns (uint newTakerId, uint newProviderId, int toTaker, int toProvider)
+    {
+        RollOffer memory offer = rollOffers[rollId];
+
+        // offer doesn't exist, was cancelled, or executed
         require(offer.active, "invalid offer");
-        // store the inactive state before external calls as extra reentrancy precaution
-        // @dev this writes to storage
-        offer.active = false;
+        // auth, will revert if takerId was burned already
+        require(msg.sender == takerNFT.ownerOf(offer.takerId), "not taker ID owner");
+
+        // @dev an expired position should settle at some past price, so if rolling after expiry is allowed,
+        // a different price may be used in settlement calculations instead of current price.
+        // This is prevented by this check, since supporting the complexity of such scenarios is not needed.
+        uint expiration = takerNFT.getPosition(offer.takerId).expiration;
+        require(block.timestamp <= expiration, "taker position expired");
 
         // offer is within its terms
         uint newPrice = takerNFT.currentOraclePrice();
@@ -260,127 +249,79 @@ contract Rolls is IRolls, BaseManaged {
         require(newPrice >= offer.minPrice, "price too low");
         require(block.timestamp <= offer.deadline, "deadline passed");
 
-        // auth, will revert if takerId was burned already
-        require(msg.sender == takerNFT.ownerOf(offer.takerId), "not taker ID owner");
+        // @dev only this line writes to storage. Update storage here for CEI
+        rollOffers[rollId].active = false;
 
-        // position is not settled yet. it must exist still (otherwise ownerOf would revert)
-        CollarTakerNFT.TakerPosition memory takerPos = takerNFT.getPosition(offer.takerId);
-        require(!takerPos.settled, "taker position settled");
-        // @dev an expired position should settle at some past price, so if rolling after expiry is allowed,
-        // a different price may be used in settlement calculations instead of current price.
-        // This is prevented by this check, since supporting the complexity of such scenarios is not needed.
-        require(block.timestamp <= takerPos.expiration, "taker position expired");
+        int rollFee = calculateRollFee(offer, newPrice);
 
-        (newTakerId, newProviderId, toTaker, toProvider) = _executeRoll(rollId, newPrice, takerPos);
-
-        // check transfers are sufficient / or pulls are not excessive
+        // preview the transfer amounts first, because cash may need to be pulled first
+        (toTaker, toProvider) = _previewTransferAmounts(offer.takerId, newPrice, rollFee);
+        // check transfers are sufficient / or pulls are not excessive. Only the preview
+        // values will be used to pull / pay cash, so checking them is correct.
+        // This contract does not hold any resting balance, so no other assets are available.
+        // If preview amounts do not match actual amounts, _executeRoll will revert.
         require(toTaker >= minToTaker, "taker transfer slippage");
         require(toProvider >= offer.minToProvider, "provider transfer slippage");
+
+        (newTakerId, newProviderId) = _executeRoll(offer, newPrice, toTaker, toProvider);
+
+        emit OfferExecuted(rollId, toTaker, toProvider, rollFee, newTakerId, newProviderId);
     }
 
     // ----- INTERNAL MUTATIVE ----- //
 
-    function _executeRoll(uint rollId, uint newPrice, CollarTakerNFT.TakerPosition memory takerPos)
+    function _executeRoll(RollOffer memory offer, uint newPrice, int toTaker, int toProvider)
         internal
-        returns (uint newTakerId, uint newProviderId, int toTaker, int toProvider)
+        returns (uint newTakerId, uint newProviderId)
     {
-        // @dev this is memory, not storage
-        RollOffer memory offer = rollOffers[rollId];
-
-        CollarProviderNFT providerNFT = takerPos.providerNFT;
-        CollarProviderNFT.ProviderPosition memory providerPos = providerNFT.getPosition(takerPos.providerId);
-        // calculate the transfer amounts
-        int rollFee = calculateRollFee(offer, newPrice);
-        (toTaker, toProvider) = _calculateTransferAmounts({
-            newPrice: newPrice,
-            rollFeeAmount: rollFee,
-            takerId: offer.takerId,
-            providerPos: providerPos
-        });
-
         // pull the taker NFT from the user (we already have the provider NFT)
         takerNFT.transferFrom(msg.sender, address(this), offer.takerId);
-        // now that we have both NFTs, cancel the positions and withdraw
-        _cancelPairedPositionAndWithdraw(offer.takerId, takerPos);
 
-        // pull cash as needed
-        _pullCash(toTaker, msg.sender, toProvider, offer.provider);
+        // now that we have both NFTs, cancel the positions and withdraw
+        _cancelPairedPositionAndWithdraw(offer.takerId);
+
+        // pull cash as needed. This needs to be done before opening new positions
+        address provider = offer.provider;
+        // assumes approval from the taker, Reverts for type(int).min
+        if (toTaker < 0) cashAsset.safeTransferFrom(msg.sender, address(this), uint(-toTaker));
+        // assumes approval from the provider. Reverts for type(int).min
+        if (toProvider < 0) cashAsset.safeTransferFrom(provider, address(this), uint(-toProvider));
 
         // open the new positions
-        (newTakerId, newProviderId) = _openNewPairedPosition(newPrice, providerNFT, takerPos, providerPos);
+        (newTakerId, newProviderId) = _openNewPairedPosition(newPrice, offer.takerId);
 
         // pay cash as needed
-        _payCash(toTaker, msg.sender, toProvider, offer.provider);
+        if (toTaker > 0) cashAsset.safeTransfer(msg.sender, uint(toTaker));
+        if (toProvider > 0) cashAsset.safeTransfer(provider, uint(toProvider));
 
-        // we now own both of the NFT IDs, so send them out to their new proud owners
+        // we now own both of the new NFT IDs, so send them out to their new proud owners
         takerNFT.transferFrom(address(this), msg.sender, newTakerId);
-        providerNFT.transferFrom(address(this), offer.provider, newProviderId);
-
-        emit OfferExecuted(
-            rollId,
-            offer.takerId,
-            offer.providerNFT,
-            offer.providerId,
-            toTaker,
-            toProvider,
-            rollFee,
-            newTakerId,
-            newProviderId
-        );
+        offer.providerNFT.transferFrom(address(this), offer.provider, newProviderId);
     }
 
-    function _pullCash(int toTaker, address taker, int toProvider, address provider) internal {
-        if (toTaker < 0) {
-            // assumes approval from the taker, @dev reverts for type(int).min
-            cashAsset.safeTransferFrom(taker, address(this), uint(-toTaker));
-        }
-        if (toProvider < 0) {
-            // @dev this requires the original owner of the providerId (stored in the offer) when
-            // the roll offer was created to still allow this contract to pull their funds, and
-            // still have sufficient balance for that. Reverts for type(int).min
-            cashAsset.safeTransferFrom(provider, address(this), uint(-toProvider));
-        }
-    }
-
-    function _payCash(int toTaker, address taker, int toProvider, address provider) internal {
-        if (toTaker > 0) {
-            cashAsset.safeTransfer(taker, uint(toTaker));
-        }
-        if (toProvider > 0) {
-            cashAsset.safeTransfer(provider, uint(toProvider));
-        }
-    }
-
-    function _cancelPairedPositionAndWithdraw(uint takerId, CollarTakerNFT.TakerPosition memory takerPos)
-        internal
-    {
+    function _cancelPairedPositionAndWithdraw(uint takerId) internal {
+        CollarTakerNFT.TakerPosition memory takerPos = takerNFT.getPosition(takerId);
         // approve the takerNFT to pull the provider NFT, as both NFTs are needed for cancellation
         takerPos.providerNFT.approve(address(takerNFT), takerPos.providerId);
         // cancel and withdraw the cash from the existing paired position
         // @dev this relies on being the owner of both NFTs. it burns both NFTs, and withdraws
         // both put and locked cash to this contract
-        uint balanceBefore = cashAsset.balanceOf(address(this));
-        takerNFT.cancelPairedPosition(takerId, address(this));
-        uint withdrawn = cashAsset.balanceOf(address(this)) - balanceBefore;
-        // @dev if this changes, the calculations need to be updated
+        uint withdrawn = takerNFT.cancelPairedPosition(takerId);
         uint expectedAmount = takerPos.takerLocked + takerPos.providerLocked;
+        // @dev this invariant is assumed by the transfer calculations
         require(withdrawn == expectedAmount, "unexpected withdrawal amount");
     }
 
-    function _openNewPairedPosition(
-        uint currentPrice,
-        CollarProviderNFT providerNFT,
-        CollarTakerNFT.TakerPosition memory takerPos,
-        CollarProviderNFT.ProviderPosition memory providerPos
-    ) internal returns (uint newTakerId, uint newProviderId) {
+    function _openNewPairedPosition(uint newPrice, uint takerId)
+        internal
+        returns (uint newTakerId, uint newProviderId)
+    {
+        CollarTakerNFT.TakerPosition memory takerPos = takerNFT.getPosition(takerId);
+        CollarProviderNFT providerNFT = takerPos.providerNFT;
+        CollarProviderNFT.ProviderPosition memory providerPos = providerNFT.getPosition(takerPos.providerId);
+
         // calculate locked amounts for new positions
-        (uint newTakerLocked, uint newProviderLocked) = _newLockedAmounts({
-            startPrice: takerPos.initialPrice,
-            newPrice: currentPrice,
-            takerLocked: takerPos.takerLocked,
-            putPercent: providerPos.putStrikePercent,
-            callPercent: providerPos.callStrikePercent
-        });
+        (uint newTakerLocked, uint newProviderLocked) = _newLockedAmounts(takerPos, providerPos, newPrice);
 
         // add the protocol fee that will be taken from the offer
         (uint protocolFee,) = providerNFT.protocolFee(newProviderLocked, takerPos.duration);
@@ -403,48 +344,53 @@ contract Rolls is IRolls, BaseManaged {
 
     // ----- INTERNAL VIEWS ----- //
 
-    function _calculateTransferAmounts(
-        uint newPrice,
-        int rollFeeAmount,
-        uint takerId,
-        CollarProviderNFT.ProviderPosition memory providerPos
-    ) internal view returns (int toTaker, int toProvider) {
-        // what would the taker and provider get from a settlement of the old position at current settlement price
-        (uint takerSettled, int providerGain) = takerNFT.previewSettlement(takerId, newPrice);
+    /// @dev calculates everything that will happen in _executeRoll. This assumes full, down to the wei,
+    /// match of all amounts between "preview" and actual "execution". If implementations change, a different
+    /// Rolls contracts will need to be used for them. Roll contracts are assumed
+    /// to be easy to replace and migrate (only unexecuted offers need to be cancelled)
+    function _previewTransferAmounts(uint takerId, uint newPrice, int rollFeeAmount)
+        internal
+        view
+        returns (int toTaker, int toProvider)
+    {
         CollarTakerNFT.TakerPosition memory takerPos = takerNFT.getPosition(takerId);
+        CollarProviderNFT providerNFT = takerPos.providerNFT;
+        CollarProviderNFT.ProviderPosition memory providerPos = providerNFT.getPosition(takerPos.providerId);
+
+        // what would the taker and provider get from a settlement of the old position at current price
+        (uint takerSettled, int providerGain) = takerNFT.previewSettlement(takerId, newPrice);
+        // provider settled is locked + its settlement gain
         int providerSettled = takerPos.providerLocked.toInt256() + providerGain;
 
         // what are the new locked amounts as they will be calculated when opening the new positions
-        (uint newTakerLocked, uint newProviderLocked) = _newLockedAmounts({
-            startPrice: takerPos.initialPrice,
-            newPrice: newPrice,
-            takerLocked: takerPos.takerLocked,
-            putPercent: providerPos.putStrikePercent,
-            callPercent: providerPos.callStrikePercent
-        });
+        (uint newTakerLocked, uint newProviderLocked) = _newLockedAmounts(takerPos, providerPos, newPrice);
 
-        (uint protocolFee,) = takerPos.providerNFT.protocolFee(newProviderLocked, takerPos.duration);
+        // new protocol fee. @dev there is no refund for previously paid protocol fee
+        (uint protocolFee,) = providerNFT.protocolFee(newProviderLocked, takerPos.duration);
 
-        // The taker and provider external balances (before fee) should be updated according to
-        // their PNL: the money released from their settled position minus the cost of opening the new position.
-        // The roll-fee is applied, and can represent any arbitrary adjustment to this (that's expressed by the offer).
+        // The taker and provider external balances (before fee) should be updated as if
+        // they settled and withdrawn the old positions, and opened the new positions.
+        // The roll-fee is paid to the provider by the taker, and can represent any arbitrary adjustment
+        // to this (that's expressed by the offer).
         toTaker = takerSettled.toInt256() - newTakerLocked.toInt256() - rollFeeAmount;
         toProvider = providerSettled - newProviderLocked.toInt256() + rollFeeAmount - protocolFee.toInt256();
 
-        /*  Does this balance out? Vars:
+        /*  Proof.
+
+            Vars:
                 Ts: takerSettled, Ps: providerSettled, put: newTakerLocked,
                 call: newProviderLocked, rollFee: rollFee, proFee: protocolFee
 
             After settlement (after cancelling and withdrawing old position):
-                Contract balance    = Ts + Ps
+                Contract balance = Ts + Ps
 
             Then contract receives / pays:
-                1. toPairedPosition =           put + call
-                2. toTaker          = Ts      - put        - rollFee
-                3. toProvider       =      Ps       - call + rollFee - proFee
-                4. toProtocol       =                                + proFee
+            1.  toPairedPosition =           put + call
+            2.  toTaker          = Ts      - put        - rollFee
+            3.  toProvider       =      Ps       - call + rollFee - proFee
+            4.  toProtocol       =                                + proFee
 
-            All payments summed     = Ts + Ps
+            All payments summed  = Ts + Ps
 
             So the contract pays out everything it receives, and everyone gets their correct updates.
         */
@@ -452,19 +398,19 @@ contract Rolls is IRolls, BaseManaged {
 
     // @dev the amounts needed for a new position given the old position
     function _newLockedAmounts(
-        uint startPrice,
-        uint newPrice,
-        uint takerLocked,
-        uint putPercent,
-        uint callPercent
+        CollarTakerNFT.TakerPosition memory takerPos,
+        CollarProviderNFT.ProviderPosition memory providerPos,
+        uint newPrice
     ) internal view returns (uint newTakerLocked, uint newProviderLocked) {
-        // simply scale up using price. As the takerLocked is the main input to CollarTakerNFT's
-        // open, this determines the new funds needed.
-        // The reason this needs to be scaled with price, instead of just using the previous amount
-        // is that this can serve the loans use-case, where the "underlying" value (price exposure) is
-        // maintained constant (instead of the dollar amount).
-        newTakerLocked = takerLocked * newPrice / startPrice; // zero start price is invalid and will cause panic
+        // New position is determined by calculating newTakerLocked, since it is the input argument.
+        // Scale up using price to maintain same level of exposure to underlying asset.
+        // The reason this needs to be scaled with price, is that this can should fit the loans use-case
+        // where the position should track the value of the initial amount of underlying asset
+        // (price exposure), instead of (for example) initial cash amount.
+        newTakerLocked = takerPos.takerLocked * newPrice / takerPos.startPrice; // zero start price is invalid and will cause panic
         // use the method that CollarTakerNFT will use to calculate the provider part
-        newProviderLocked = takerNFT.calculateProviderLocked(newTakerLocked, putPercent, callPercent);
+        newProviderLocked = takerNFT.calculateProviderLocked(
+            newTakerLocked, providerPos.putStrikePercent, providerPos.callStrikePercent
+        );
     }
 }

--- a/src/Rolls.sol
+++ b/src/Rolls.sol
@@ -461,7 +461,7 @@ contract Rolls is IRolls, BaseManaged {
         // simply scale up using price. As the takerLocked is the main input to CollarTakerNFT's
         // open, this determines the new funds needed.
         // The reason this needs to be scaled with price, instead of just using the previous amount
-        // is that this can serve the loans use-case, where the "collateral" value (price exposure) is
+        // is that this can serve the loans use-case, where the "underlying" value (price exposure) is
         // maintained constant (instead of the dollar amount).
         newTakerLocked = takerLocked * newPrice / startPrice; // zero start price is invalid and will cause panic
         // use the method that CollarTakerNFT will use to calculate the provider part

--- a/src/Rolls.sol
+++ b/src/Rolls.sol
@@ -378,8 +378,8 @@ contract Rolls is IRolls, BaseEmergencyAdmin {
             startPrice: takerPos.initialPrice,
             newPrice: currentPrice,
             takerLocked: takerPos.takerLocked,
-            putDeviation: providerPos.putStrikeDeviation,
-            callDeviation: providerPos.callStrikeDeviation
+            putPercent: providerPos.putStrikePercent,
+            callPercent: providerPos.callStrikePercent
         });
 
         // add the protocol fee that will be taken from the offer
@@ -389,9 +389,9 @@ contract Rolls is IRolls, BaseEmergencyAdmin {
         // create a liquidity offer just for this roll
         cashAsset.forceApprove(address(providerNFT), offerAmount);
         uint liquidityOfferId = providerNFT.createOffer({
-            callStrikeDeviation: providerPos.callStrikeDeviation,
+            callStrikePercent: providerPos.callStrikePercent,
             amount: offerAmount,
-            putStrikeDeviation: providerPos.putStrikeDeviation,
+            putStrikePercent: providerPos.putStrikePercent,
             duration: takerPos.duration
         });
 
@@ -418,8 +418,8 @@ contract Rolls is IRolls, BaseEmergencyAdmin {
             startPrice: takerPos.initialPrice,
             newPrice: newPrice,
             takerLocked: takerPos.takerLocked,
-            putDeviation: providerPos.putStrikeDeviation,
-            callDeviation: providerPos.callStrikeDeviation
+            putPercent: providerPos.putStrikePercent,
+            callPercent: providerPos.callStrikePercent
         });
 
         (uint protocolFee,) = takerPos.providerNFT.protocolFee(newProviderLocked, takerPos.duration);
@@ -454,8 +454,8 @@ contract Rolls is IRolls, BaseEmergencyAdmin {
         uint startPrice,
         uint newPrice,
         uint takerLocked,
-        uint putDeviation,
-        uint callDeviation
+        uint putPercent,
+        uint callPercent
     ) internal view returns (uint newTakerLocked, uint newProviderLocked) {
         // simply scale up using price. As the takerLocked is the main input to CollarTakerNFT's
         // open, this determines the new funds needed.
@@ -464,6 +464,6 @@ contract Rolls is IRolls, BaseEmergencyAdmin {
         // maintained constant (instead of the dollar amount).
         newTakerLocked = takerLocked * newPrice / startPrice; // zero start price is invalid and will cause panic
         // use the method that CollarTakerNFT will use to calculate the provider part
-        newProviderLocked = takerNFT.calculateProviderLocked(newTakerLocked, putDeviation, callDeviation);
+        newProviderLocked = takerNFT.calculateProviderLocked(newTakerLocked, putPercent, callPercent);
     }
 }

--- a/src/Rolls.sol
+++ b/src/Rolls.sol
@@ -12,7 +12,7 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { SignedMath } from "@openzeppelin/contracts/utils/math/SignedMath.sol";
 
 import { CollarTakerNFT, CollarProviderNFT } from "./CollarTakerNFT.sol";
-import { BaseEmergencyAdmin } from "./base/BaseEmergencyAdmin.sol";
+import {BaseManaged} from "./base/BaseManaged.sol";
 import { IRolls } from "./interfaces/IRolls.sol";
 
 /**
@@ -49,7 +49,7 @@ import { IRolls } from "./interfaces/IRolls.sol";
  * 2. Signed integers are used for many input and output values, and proper care should be
  * taken in understanding the semantics of the positive and negative values.
  */
-contract Rolls is IRolls, BaseEmergencyAdmin {
+contract Rolls is IRolls, BaseManaged {
     using SafeERC20 for IERC20;
     using SafeCast for uint;
 
@@ -70,7 +70,7 @@ contract Rolls is IRolls, BaseEmergencyAdmin {
     /// @dev Rolls needs BaseEmergencyAdmin for pausing since is approved by users, and holds NFTs.
     /// Does not need `canOpen` auth because its auth usage is set directly on Loans,
     /// and it has no long-lived functionality so doesn't need a close-only migration mode.
-    constructor(address initialOwner, CollarTakerNFT _takerNFT) BaseEmergencyAdmin(initialOwner) {
+    constructor(address initialOwner, CollarTakerNFT _takerNFT) BaseManaged(initialOwner) {
         takerNFT = _takerNFT;
         cashAsset = _takerNFT.cashAsset();
         _setConfigHub(_takerNFT.configHub());

--- a/src/Rolls.sol
+++ b/src/Rolls.sol
@@ -12,7 +12,7 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { SignedMath } from "@openzeppelin/contracts/utils/math/SignedMath.sol";
 
 import { CollarTakerNFT, CollarProviderNFT } from "./CollarTakerNFT.sol";
-import {BaseManaged} from "./base/BaseManaged.sol";
+import { BaseManaged } from "./base/BaseManaged.sol";
 import { IRolls } from "./interfaces/IRolls.sol";
 
 /**
@@ -397,7 +397,8 @@ contract Rolls is IRolls, BaseManaged {
 
         // take the liquidity offer as taker
         cashAsset.forceApprove(address(takerNFT), newTakerLocked);
-        (newTakerId, newProviderId) = takerNFT.openPairedPosition(newTakerLocked, providerNFT, liquidityOfferId);
+        (newTakerId, newProviderId) =
+            takerNFT.openPairedPosition(newTakerLocked, providerNFT, liquidityOfferId);
     }
 
     // ----- INTERNAL VIEWS ----- //

--- a/src/SwapperUniV3.sol
+++ b/src/SwapperUniV3.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
 import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/src/base/BaseManaged.sol
+++ b/src/base/BaseManaged.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
 import { SafeERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/src/base/BaseManaged.sol
+++ b/src/base/BaseManaged.sol
@@ -13,7 +13,7 @@ import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
 
 import { ConfigHub } from "../ConfigHub.sol";
 
-abstract contract BaseEmergencyAdmin is Ownable2Step, Pausable {
+abstract contract BaseManaged is Ownable2Step, Pausable {
     // ----- State ----- //
     ConfigHub public configHub;
 

--- a/src/base/BaseNFT.sol
+++ b/src/base/BaseNFT.sol
@@ -9,7 +9,7 @@ pragma solidity 0.8.22;
 
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
-import {BaseManaged, ConfigHub } from "./BaseManaged.sol";
+import { BaseManaged, ConfigHub } from "./BaseManaged.sol";
 
 abstract contract BaseNFT is BaseManaged, ERC721 {
     // ----- State ----- //

--- a/src/base/BaseNFT.sol
+++ b/src/base/BaseNFT.sol
@@ -9,14 +9,14 @@ pragma solidity 0.8.22;
 
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
-import { BaseEmergencyAdmin, ConfigHub } from "./BaseEmergencyAdmin.sol";
+import {BaseManaged, ConfigHub } from "./BaseManaged.sol";
 
-abstract contract BaseNFT is BaseEmergencyAdmin, ERC721 {
+abstract contract BaseNFT is BaseManaged, ERC721 {
     // ----- State ----- //
     uint internal nextTokenId = 1; // NFT token ID, starts from 1 so that 0 ID is not used
 
     constructor(address _initialOwner, string memory _name, string memory _symbol)
-        BaseEmergencyAdmin(_initialOwner)
+        BaseManaged(_initialOwner)
         ERC721(_name, _symbol)
     { }
 

--- a/src/base/BaseNFT.sol
+++ b/src/base/BaseNFT.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/src/interfaces/ICollarProviderNFT.sol
+++ b/src/interfaces/ICollarProviderNFT.sol
@@ -34,7 +34,7 @@ interface ICollarProviderNFT {
 
     // events
     event CollarProviderNFTCreated(
-        address indexed cashAsset, address indexed collateralAsset, address indexed takerContract
+        address indexed cashAsset, address indexed underlying, address indexed takerContract
     );
     event OfferCreated(
         address indexed provider,

--- a/src/interfaces/ICollarProviderNFT.sol
+++ b/src/interfaces/ICollarProviderNFT.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: GPL 2.0
 pragma solidity 0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -49,8 +43,6 @@ interface ICollarProviderNFT {
         uint indexed positionId, uint indexed offerId, uint feeAmount, ProviderPosition position
     );
     event PositionSettled(uint indexed positionId, int positionChange, uint withdrawable);
-    event WithdrawalFromSettled(uint indexed positionId, address indexed recipient, uint withdrawn);
-    event PositionCanceled(
-        uint indexed positionId, address indexed recipient, uint withdrawn, uint expiration
-    );
+    event WithdrawalFromSettled(uint indexed positionId, uint withdrawn);
+    event PositionCanceled(uint indexed positionId, uint withdrawn, uint expiration);
 }

--- a/src/interfaces/ICollarProviderNFT.sol
+++ b/src/interfaces/ICollarProviderNFT.sol
@@ -10,7 +10,7 @@ pragma solidity 0.8.22;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ConfigHub } from "../ConfigHub.sol";
 
-interface IShortProviderNFT {
+interface ICollarProviderNFT {
     struct LiquidityOffer {
         address provider;
         uint available;
@@ -33,7 +33,7 @@ interface IShortProviderNFT {
     }
 
     // events
-    event ShortProviderNFTCreated(
+    event CollarProviderNFTCreated(
         address indexed cashAsset, address indexed collateralAsset, address indexed takerContract
     );
     event OfferCreated(

--- a/src/interfaces/ICollarTakerNFT.sol
+++ b/src/interfaces/ICollarTakerNFT.sol
@@ -26,7 +26,7 @@ interface ICollarTakerNFT {
         uint putStrikePrice;
         uint callStrikePrice;
         uint takerLocked;
-        uint callLockedCash;
+        uint providerLocked;
         // withdrawal state
         bool settled;
         uint withdrawable;

--- a/src/interfaces/ICollarTakerNFT.sol
+++ b/src/interfaces/ICollarTakerNFT.sol
@@ -34,7 +34,7 @@ interface ICollarTakerNFT {
 
     // events
     event CollarTakerNFTCreated(
-        address indexed cashAsset, address indexed collateralAsset, address indexed oracle
+        address indexed cashAsset, address indexed underlying, address indexed oracle
     );
     event PairedPositionOpened(
         uint indexed takerId,

--- a/src/interfaces/ICollarTakerNFT.sol
+++ b/src/interfaces/ICollarTakerNFT.sol
@@ -9,7 +9,7 @@ pragma solidity 0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ConfigHub } from "../ConfigHub.sol";
-import { ShortProviderNFT } from "../ShortProviderNFT.sol";
+import { CollarProviderNFT } from "../CollarProviderNFT.sol";
 import { OracleUniV3TWAP } from "../OracleUniV3TWAP.sol";
 
 interface ICollarTakerNFT {
@@ -17,7 +17,7 @@ interface ICollarTakerNFT {
     // and are stored for FE / usability since the assumption is that this is used on L2.
     struct TakerPosition {
         // paired NFT info
-        ShortProviderNFT providerNFT;
+        CollarProviderNFT providerNFT;
         uint providerId;
         // collar position info
         uint duration;

--- a/src/interfaces/ICollarTakerNFT.sol
+++ b/src/interfaces/ICollarTakerNFT.sol
@@ -1,16 +1,10 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: GPL 2.0
 pragma solidity 0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ConfigHub } from "../ConfigHub.sol";
 import { CollarProviderNFT } from "../CollarProviderNFT.sol";
-import { OracleUniV3TWAP } from "../OracleUniV3TWAP.sol";
+import { ITakerOracle } from "./ITakerOracle.sol";
 
 interface ICollarTakerNFT {
     // @dev Some data can be trimmed down from this struct, since some of the fields aren't needed on-chain,
@@ -22,7 +16,7 @@ interface ICollarTakerNFT {
         // collar position info
         uint duration;
         uint expiration;
-        uint initialPrice;
+        uint startPrice;
         uint putStrikePrice;
         uint callStrikePrice;
         uint takerLocked;
@@ -56,10 +50,9 @@ interface ICollarTakerNFT {
         uint indexed takerId,
         address indexed providerNFT,
         uint indexed providerId,
-        address recipient,
         uint withdrawn,
         uint expiration
     );
-    event WithdrawalFromSettled(uint indexed takerId, address indexed recipient, uint withdrawn);
-    event OracleSet(OracleUniV3TWAP prevOracle, OracleUniV3TWAP newOracle);
+    event WithdrawalFromSettled(uint indexed takerId, uint withdrawn);
+    event OracleSet(ITakerOracle prevOracle, ITakerOracle newOracle);
 }

--- a/src/interfaces/ICollarTakerNFT.sol
+++ b/src/interfaces/ICollarTakerNFT.sol
@@ -25,7 +25,7 @@ interface ICollarTakerNFT {
         uint initialPrice;
         uint putStrikePrice;
         uint callStrikePrice;
-        uint putLockedCash;
+        uint takerLocked;
         uint callLockedCash;
         // withdrawal state
         bool settled;

--- a/src/interfaces/IConfigHub.sol
+++ b/src/interfaces/IConfigHub.sol
@@ -8,7 +8,7 @@
 pragma solidity 0.8.22;
 
 interface IConfigHub {
-    event CollateralAssetSupportSet(address indexed collateralAsset, bool indexed enabled);
+    event UnderlyingSupportSet(address indexed underlying, bool indexed enabled);
     event CashAssetSupportSet(address indexed cashAsset, bool indexed enabled);
     event LTVRangeSet(uint indexed minLTV, uint indexed maxLTV);
     event CollarDurationRangeSet(uint indexed minDuration, uint indexed maxDuration);

--- a/src/interfaces/IConfigHub.sol
+++ b/src/interfaces/IConfigHub.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: GPL 2.0
 pragma solidity 0.8.22;
 
 interface IConfigHub {

--- a/src/interfaces/IEscrowSupplierNFT.sol
+++ b/src/interfaces/IEscrowSupplierNFT.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: GPL 2.0
 pragma solidity 0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/src/interfaces/ILoansNFT.sol
+++ b/src/interfaces/ILoansNFT.sol
@@ -10,7 +10,7 @@ pragma solidity 0.8.22;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ConfigHub } from "../ConfigHub.sol";
 import { CollarTakerNFT } from "../CollarTakerNFT.sol";
-import { ShortProviderNFT } from "../ShortProviderNFT.sol";
+import { CollarProviderNFT } from "../CollarProviderNFT.sol";
 import { Rolls } from "../Rolls.sol";
 import { EscrowSupplierNFT } from "../EscrowSupplierNFT.sol";
 
@@ -33,7 +33,7 @@ interface ILoansNFT {
     event LoanOpened(
         uint indexed loanId,
         address indexed sender,
-        uint indexed shortOfferId,
+        uint indexed providerOfferId,
         uint collateralAmount,
         uint loanAmount
     );
@@ -58,7 +58,7 @@ interface ILoansNFT {
     event ClosingKeeperAllowed(address indexed sender, bool indexed enabled);
     event ClosingKeeperUpdated(address indexed previousKeeper, address indexed newKeeper);
     event ContractsUpdated(
-        Rolls indexed rolls, ShortProviderNFT indexed providerNFT, EscrowSupplierNFT indexed escrowNFT
+        Rolls indexed rolls, CollarProviderNFT indexed providerNFT, EscrowSupplierNFT indexed escrowNFT
     );
     event SwapperSet(address indexed swapper, bool indexed allowed, bool indexed setDefault);
     event EscrowSettled(uint indexed escrowId, uint lateFee, uint toEscrow, uint fromEscrow, uint leftOver);

--- a/src/interfaces/ILoansNFT.sol
+++ b/src/interfaces/ILoansNFT.sol
@@ -16,7 +16,7 @@ import { EscrowSupplierNFT } from "../EscrowSupplierNFT.sol";
 
 interface ILoansNFT {
     struct Loan {
-        uint collateralAmount;
+        uint underlyingAmount;
         uint loanAmount;
         bool usesEscrow;
         EscrowSupplierNFT escrowNFT; // optional, 0 address for non-escrow loans
@@ -24,7 +24,7 @@ interface ILoansNFT {
     }
 
     struct SwapParams {
-        uint minAmountOut; // can be cash or collateral, in correct token units
+        uint minAmountOut; // can be cash or underlying, in correct token units
         address swapper;
         bytes extraData;
     }
@@ -34,7 +34,7 @@ interface ILoansNFT {
         uint indexed loanId,
         address indexed sender,
         uint indexed providerOfferId,
-        uint collateralAmount,
+        uint underlyingAmount,
         uint loanAmount
     );
     event LoanClosed(
@@ -43,7 +43,7 @@ interface ILoansNFT {
         address indexed user,
         uint repayment,
         uint cashAmount,
-        uint collateralOut
+        uint underlyingOut
     );
     event LoanRolled(
         address indexed sender,

--- a/src/interfaces/ILoansNFT.sol
+++ b/src/interfaces/ILoansNFT.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: GPL 2.0
 pragma solidity 0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/src/interfaces/ILoansNFT.sol
+++ b/src/interfaces/ILoansNFT.sol
@@ -55,7 +55,7 @@ interface ILoansNFT {
         int transferAmount
     );
     event LoanCancelled(uint indexed loanId, address indexed sender);
-    event ClosingKeeperAllowed(address indexed sender, bool indexed enabled);
+    event ClosingKeeperApproved(address indexed sender, bool indexed enabled);
     event ClosingKeeperUpdated(address indexed previousKeeper, address indexed newKeeper);
     event ContractsUpdated(
         Rolls indexed rolls, CollarProviderNFT indexed providerNFT, EscrowSupplierNFT indexed escrowNFT

--- a/src/interfaces/IRolls.sol
+++ b/src/interfaces/IRolls.sol
@@ -15,9 +15,9 @@ interface IRolls {
     struct RollOffer {
         // terms
         uint takerId;
-        int rollFeeAmount;
-        int rollFeeDeltaFactorBIPS; // bips change of fee amount for delta (ratio) of price change
-        uint rollFeeReferencePrice;
+        int feeAmount;
+        int feeDeltaFactorBIPS; // bips change of fee amount for delta (ratio) of price change
+        uint feeReferencePrice;
         // provider protection
         uint minPrice;
         uint maxPrice;

--- a/src/interfaces/IRolls.sol
+++ b/src/interfaces/IRolls.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: GPL 2.0
 pragma solidity 0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -42,14 +36,6 @@ interface IRolls {
     );
     event OfferCancelled(uint indexed rollId, uint indexed takerId, address indexed provider);
     event OfferExecuted(
-        uint indexed rollId,
-        uint indexed takerId,
-        CollarProviderNFT indexed providerNFT,
-        uint providerId,
-        int toTaker,
-        int toProvider,
-        int rollFee,
-        uint newTakerId,
-        uint newProviderId
+        uint indexed rollId, int toTaker, int toProvider, int rollFee, uint newTakerId, uint newProviderId
     );
 }

--- a/src/interfaces/IRolls.sol
+++ b/src/interfaces/IRolls.sol
@@ -9,7 +9,7 @@ pragma solidity 0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { CollarTakerNFT } from "../CollarTakerNFT.sol";
-import { ShortProviderNFT } from "../ShortProviderNFT.sol";
+import { CollarProviderNFT } from "../CollarProviderNFT.sol";
 
 interface IRolls {
     struct RollOffer {
@@ -24,7 +24,7 @@ interface IRolls {
         int minToProvider;
         uint deadline;
         // somewhat redundant (since it comes from the taker ID), but safer for cancellations
-        ShortProviderNFT providerNFT;
+        CollarProviderNFT providerNFT;
         uint providerId;
         // state
         address provider;
@@ -35,7 +35,7 @@ interface IRolls {
     event OfferCreated(
         uint indexed takerId,
         address indexed provider,
-        ShortProviderNFT indexed providerNFT,
+        CollarProviderNFT indexed providerNFT,
         uint providerId,
         int rollFeeAmount,
         uint rollId
@@ -44,7 +44,7 @@ interface IRolls {
     event OfferExecuted(
         uint indexed rollId,
         uint indexed takerId,
-        ShortProviderNFT indexed providerNFT,
+        CollarProviderNFT indexed providerNFT,
         uint providerId,
         int toTaker,
         int toProvider,

--- a/src/interfaces/IShortProviderNFT.sol
+++ b/src/interfaces/IShortProviderNFT.sol
@@ -15,8 +15,8 @@ interface IShortProviderNFT {
         address provider;
         uint available;
         // terms
-        uint putStrikeDeviation;
-        uint callStrikeDeviation;
+        uint putStrikePercent;
+        uint callStrikePercent;
         uint duration;
     }
 
@@ -25,8 +25,8 @@ interface IShortProviderNFT {
         // collar position terms
         uint expiration;
         uint principal;
-        uint putStrikeDeviation;
-        uint callStrikeDeviation;
+        uint putStrikePercent;
+        uint callStrikePercent;
         // withdrawal
         bool settled;
         uint withdrawable;
@@ -38,9 +38,9 @@ interface IShortProviderNFT {
     );
     event OfferCreated(
         address indexed provider,
-        uint indexed putStrikeDeviation,
+        uint indexed putStrikePercent,
         uint indexed duration,
-        uint callStrikeDeviation,
+        uint callStrikePercent,
         uint amount,
         uint offerId
     );

--- a/src/interfaces/ISwapper.sol
+++ b/src/interfaces/ISwapper.sol
@@ -1,10 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
+// SPDX-License-Identifier: GPL 2.0
 pragma solidity 0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/src/interfaces/ITakerOracle.sol
+++ b/src/interfaces/ITakerOracle.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL 2.0
+pragma solidity 0.8.22;
+
+// The interface that is relied on by contracts
+interface ITakerOracle {
+    function baseToken() external view returns (address);
+    function quoteToken() external view returns (address);
+    function currentPrice() external view returns (uint);
+    function pastPriceWithFallback(uint32 timestamp) external view returns (uint price, bool historical);
+    function BASE_TOKEN_AMOUNT() external view returns (uint128);
+}

--- a/test/integration/ArbitrumMainnet.t.sol
+++ b/test/integration/ArbitrumMainnet.t.sol
@@ -85,7 +85,7 @@ contract ForkTestCollarArbitrumMainnetIntegrationTest is
 
         // (uint userWithdrawnAmount, uint providerWithdrawnAmount) = settleAndWithdraw(borrowId);
         // assertEq(userWithdrawnAmount, position.takerLocked, "User should receive put locked cash");
-        // assertEq(providerWithdrawnAmount, position.callLockedCash, "Provider should receive call locked cash");
+        // assertEq(providerWithdrawnAmount, position.providerLocked, "Provider should receive call locked cash");
 
         // assertEq(
         //     pair.cashAsset.balanceOf(user),

--- a/test/integration/ArbitrumMainnet.t.sol
+++ b/test/integration/ArbitrumMainnet.t.sol
@@ -25,7 +25,7 @@ contract ForkTestCollarArbitrumMainnetIntegrationTest is
         _setupConfig({
             _swapRouter: 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45,
             _cashAsset: 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8, // USDC
-            _collateralAsset: 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1, // WETH
+            _underlying: 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1, // WETH
             _uniV3Pool: 0x17c14D2c404D167802b16C450d3c99F88F2c4F4d,
             whaleWallet: 0xB38e8c17e38363aF6EbdCb3dAE12e0243582891D,
             blockNumber: _blockNumberToUse,
@@ -99,15 +99,15 @@ contract ForkTestCollarArbitrumMainnetIntegrationTest is
         // );
     }
 
-    function testFuzz_openAndClosePositionPriceUnderPutStrike(uint collateralAmount, uint24 callStrikeTick)
+    function testFuzz_openAndClosePositionPriceUnderPutStrike(uint underlyingAmount, uint24 callStrikeTick)
         public
         assumeValidCallStrikeTick(callStrikeTick)
     {
-        collateralAmount = bound(collateralAmount, 1 ether, 20 ether);
+        underlyingAmount = bound(underlyingAmount, 1 ether, 20 ether);
         callStrikeTick = uint24(bound(callStrikeTick, uint(110), uint(130)));
 
         (uint borrowId,) =
-            openTakerPositionAndCheckValues(collateralAmount, 0.3e6, getOfferIndex(callStrikeTick));
+            openTakerPositionAndCheckValues(underlyingAmount, 0.3e6, getOfferIndex(callStrikeTick));
         uint userCashBalanceAfterOpen = pair.cashAsset.balanceOf(user);
         uint providerCashBalanceBeforeClose = pair.cashAsset.balanceOf(provider);
 
@@ -131,14 +131,14 @@ contract ForkTestCollarArbitrumMainnetIntegrationTest is
     }
 
     function testFuzz_openAndClosePositionPriceDownShortOfPutStrike(
-        uint collateralAmount,
+        uint underlyingAmount,
         uint24 callStrikeTick
     ) public assumeValidCallStrikeTick(callStrikeTick) {
-        collateralAmount = bound(collateralAmount, 1 ether, 20 ether);
+        underlyingAmount = bound(underlyingAmount, 1 ether, 20 ether);
         callStrikeTick = uint24(bound(callStrikeTick, uint(110), uint(130)));
 
         (uint borrowId,) =
-            openTakerPositionAndCheckValues(collateralAmount, 0.3e6, getOfferIndex(callStrikeTick));
+            openTakerPositionAndCheckValues(underlyingAmount, 0.3e6, getOfferIndex(callStrikeTick));
         uint userCashBalanceAfterOpen = pair.cashAsset.balanceOf(user);
         uint providerCashBalanceBeforeClose = pair.cashAsset.balanceOf(provider);
 
@@ -165,15 +165,15 @@ contract ForkTestCollarArbitrumMainnetIntegrationTest is
         );
     }
 
-    function testFuzz_openAndClosePositionPriceUpPastCallStrike(uint collateralAmount, uint24 callStrikeTick)
+    function testFuzz_openAndClosePositionPriceUpPastCallStrike(uint underlyingAmount, uint24 callStrikeTick)
         public
         assumeValidCallStrikeTick(callStrikeTick)
     {
-        collateralAmount = bound(collateralAmount, 1 ether, 20 ether);
+        underlyingAmount = bound(underlyingAmount, 1 ether, 20 ether);
         callStrikeTick = uint24(bound(callStrikeTick, uint(110), uint(130)));
 
         (uint borrowId,) =
-            openTakerPositionAndCheckValues(collateralAmount, 0.3e6, getOfferIndex(callStrikeTick));
+            openTakerPositionAndCheckValues(underlyingAmount, 0.3e6, getOfferIndex(callStrikeTick));
         uint userCashBalanceAfterOpen = pair.cashAsset.balanceOf(user);
         uint providerCashBalanceBeforeClose = pair.cashAsset.balanceOf(provider);
 
@@ -197,14 +197,14 @@ contract ForkTestCollarArbitrumMainnetIntegrationTest is
     }
 
     function testFuzz_openAndClosePositionPriceUpShortOfCallStrike(
-        uint collateralAmount,
+        uint underlyingAmount,
         uint24 callStrikeTick
     ) public assumeValidCallStrikeTick(callStrikeTick) {
-        collateralAmount = bound(collateralAmount, 1 ether, 20 ether);
+        underlyingAmount = bound(underlyingAmount, 1 ether, 20 ether);
         callStrikeTick = uint24(bound(callStrikeTick, uint(110), uint(130)));
 
         (uint borrowId,) =
-            openTakerPositionAndCheckValues(collateralAmount, 0.3e6, getOfferIndex(callStrikeTick));
+            openTakerPositionAndCheckValues(underlyingAmount, 0.3e6, getOfferIndex(callStrikeTick));
         uint userCashBalanceAfterOpen = pair.cashAsset.balanceOf(user);
         uint providerCashBalanceBeforeClose = pair.cashAsset.balanceOf(provider);
 

--- a/test/integration/ArbitrumMainnet.t.sol
+++ b/test/integration/ArbitrumMainnet.t.sol
@@ -84,7 +84,7 @@ contract ForkTestCollarArbitrumMainnetIntegrationTest is
         // uint providerCashBalanceBefore = pair.cashAsset.balanceOf(provider);
 
         // (uint userWithdrawnAmount, uint providerWithdrawnAmount) = settleAndWithdraw(borrowId);
-        // assertEq(userWithdrawnAmount, position.putLockedCash, "User should receive put locked cash");
+        // assertEq(userWithdrawnAmount, position.takerLocked, "User should receive put locked cash");
         // assertEq(providerWithdrawnAmount, position.callLockedCash, "Provider should receive call locked cash");
 
         // assertEq(

--- a/test/integration/arbitrum-mainnet/Loans.fork.t.sol
+++ b/test/integration/arbitrum-mainnet/Loans.fork.t.sol
@@ -13,14 +13,14 @@ abstract contract LoansTestBase is Test, DeploymentLoader {
 
     function createProviderOffer(
         DeploymentHelper.AssetPairContracts memory pair,
-        uint callStrikeDeviation,
+        uint callStrikePercent,
         uint amount
     ) internal returns (uint offerId) {
         vm.startPrank(provider);
         uint cashBalance = pair.cashAsset.balanceOf(provider);
         console.log("Provider cash balance: %d", cashBalance);
         pair.cashAsset.approve(address(pair.providerNFT), amount);
-        offerId = pair.providerNFT.createOffer(callStrikeDeviation, amount, pair.ltvs[0], pair.durations[0]);
+        offerId = pair.providerNFT.createOffer(callStrikePercent, amount, pair.ltvs[0], pair.durations[0]);
         vm.stopPrank();
     }
 

--- a/test/integration/arbitrum-mainnet/Loans.fork.t.sol
+++ b/test/integration/arbitrum-mainnet/Loans.fork.t.sol
@@ -27,14 +27,14 @@ abstract contract LoansTestBase is Test, DeploymentLoader {
     function openLoan(
         DeploymentHelper.AssetPairContracts memory pair,
         address user,
-        uint collateralAmount,
+        uint underlyingAmount,
         uint minLoanAmount,
         uint offerId
     ) internal returns (uint loanId, uint providerId, uint loanAmount) {
         vm.startPrank(user);
-        pair.collateralAsset.approve(address(pair.loansContract), collateralAmount);
+        pair.underlying.approve(address(pair.loansContract), underlyingAmount);
         (loanId, providerId, loanAmount) = pair.loansContract.openLoan(
-            collateralAmount,
+            underlyingAmount,
             minLoanAmount,
             ILoansNFT.SwapParams(0, address(pair.loansContract.defaultSwapper()), ""),
             offerId
@@ -46,14 +46,14 @@ abstract contract LoansTestBase is Test, DeploymentLoader {
         DeploymentHelper.AssetPairContracts memory pair,
         address user,
         uint loanId,
-        uint minCollateralOut
-    ) internal returns (uint collateralOut) {
+        uint minUnderlyingOut
+    ) internal returns (uint underlyingOut) {
         vm.startPrank(user);
         ILoansNFT.Loan memory loan = pair.loansContract.getLoan(loanId);
         // approve repayment amount in cash asset to loans contract
         pair.cashAsset.approve(address(pair.loansContract), loan.loanAmount);
-        collateralOut = pair.loansContract.closeLoan(
-            loanId, ILoansNFT.SwapParams(minCollateralOut, address(pair.loansContract.defaultSwapper()), "")
+        underlyingOut = pair.loansContract.closeLoan(
+            loanId, ILoansNFT.SwapParams(minUnderlyingOut, address(pair.loansContract.defaultSwapper()), "")
         );
         vm.stopPrank();
     }
@@ -100,17 +100,17 @@ abstract contract LoansTestBase is Test, DeploymentLoader {
 
 contract LoansForkTest is LoansTestBase {
     address cashAsset = 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8; // USDC
-    address collateralAsset = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1; // WETH
+    address underlying = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1; // WETH
     DeploymentHelper.AssetPairContracts internal pair;
     uint public forkId;
     bool public forkSet;
     uint callstrikeToUse = 12_000;
     uint offerAmount = 100_000e6;
-    uint collateralAmount = 1 ether;
+    uint underlyingAmount = 1 ether;
     int rollFee = 100e6;
     int rollDeltaFactor = 10_000;
     uint bigCashAmount = 1_000_000e6;
-    uint bigCollateralAmount = 1000 ether;
+    uint bigUnderlyingAmount = 1000 ether;
     uint slippage = 1; // 1%
 
     function setUp() public virtual override {
@@ -126,7 +126,7 @@ contract LoansForkTest is LoansTestBase {
             vm.selectFork(forkId);
         }
         super.setUp();
-        pair = getPairByAssets(address(cashAsset), address(collateralAsset));
+        pair = getPairByAssets(address(cashAsset), address(underlying));
         fundWallets();
     }
 
@@ -139,15 +139,15 @@ contract LoansForkTest is LoansTestBase {
         uint offerId = createProviderOffer(pair, callstrikeToUse, offerAmount);
 
         uint minLoanAmount = 0.3e6;
-        (uint loanId,, uint loanAmount) = openLoan(pair, user, collateralAmount, minLoanAmount, offerId);
+        (uint loanId,, uint loanAmount) = openLoan(pair, user, underlyingAmount, minLoanAmount, offerId);
 
         assertGt(loanAmount, 0);
         skip(pair.durations[0]);
-        // no price change so collateral out should be collateral in minus slippage
-        uint minCollateralOut = collateralAmount;
-        uint minCollateralOutWithSlippage = minCollateralOut * (100 - slippage) / 100;
-        uint collateralOut = closeLoan(pair, user, loanId, minCollateralOutWithSlippage);
-        assertGe(collateralOut, minCollateralOutWithSlippage);
+        // no price change so underlying out should be underlying in minus slippage
+        uint minUnderlyingOut = underlyingAmount;
+        uint minUnderlyingOutWithSlippage = minUnderlyingOut * (100 - slippage) / 100;
+        uint underlyingOut = closeLoan(pair, user, loanId, minUnderlyingOutWithSlippage);
+        assertGe(underlyingOut, minUnderlyingOutWithSlippage);
     }
 
     function testRollLoan() public {
@@ -155,7 +155,7 @@ contract LoansForkTest is LoansTestBase {
 
         uint minLoanAmount = 0.3e6;
         (uint loanId, uint providerId, uint initialLoanAmount) =
-            openLoan(pair, user, collateralAmount, minLoanAmount, offerId);
+            openLoan(pair, user, underlyingAmount, minLoanAmount, offerId);
 
         uint rollOfferId = createRollOffer(pair, provider, loanId, providerId, rollFee, rollDeltaFactor);
 
@@ -171,7 +171,7 @@ contract LoansForkTest is LoansTestBase {
         uint offerId = createProviderOffer(pair, callstrikeToUse, offerAmount);
         uint minLoanAmount = 0.3e6;
         (uint loanId, uint providerId, uint initialLoanAmount) =
-            openLoan(pair, user, collateralAmount, minLoanAmount, offerId);
+            openLoan(pair, user, underlyingAmount, minLoanAmount, offerId);
 
         // Advance time to simulate passage of time
         vm.warp(block.timestamp + pair.durations[0] - 20);
@@ -185,19 +185,19 @@ contract LoansForkTest is LoansTestBase {
         // Advance time again
         vm.warp(block.timestamp + pair.durations[0]);
 
-        uint minCollateralOut = collateralAmount * 95 / 100; // 5% slippage
-        uint collateralOut = closeLoan(pair, user, newLoanId, minCollateralOut);
+        uint minUnderlyingOut = underlyingAmount * 95 / 100; // 5% slippage
+        uint underlyingOut = closeLoan(pair, user, newLoanId, minUnderlyingOut);
 
         assertGt(initialLoanAmount, 0);
         assertGt(newLoanId, loanId);
         assertGe(int(newLoanAmount), int(initialLoanAmount) + transferAmount);
-        assertGe(collateralOut, minCollateralOut);
+        assertGe(underlyingOut, minUnderlyingOut);
     }
 
     function fundWallets() public {
         deal(address(cashAsset), user, bigCashAmount);
         deal(address(cashAsset), provider, bigCashAmount);
-        deal(address(collateralAsset), user, bigCollateralAmount);
-        deal(address(collateralAsset), provider, bigCollateralAmount);
+        deal(address(underlying), user, bigUnderlyingAmount);
+        deal(address(underlying), provider, bigUnderlyingAmount);
     }
 }

--- a/test/integration/arbitrum-mainnet/validation.t.sol
+++ b/test/integration/arbitrum-mainnet/validation.t.sol
@@ -48,7 +48,7 @@ contract DeploymentValidatorForkTest is Test, DeploymentLoader {
             assertEq(configHub.canOpen(address(pair.takerNFT)), true);
             assertEq(configHub.canOpen(address(pair.providerNFT)), true);
             assertEq(configHub.isSupportedCashAsset(address(pair.cashAsset)), true);
-            assertEq(configHub.isSupportedCollateralAsset(address(pair.collateralAsset)), true);
+            assertEq(configHub.isSupportedUnderlying(address(pair.underlying)), true);
 
             for (uint j = 0; j < pair.durations.length; j++) {
                 assertEq(configHub.isValidCollarDuration(pair.durations[j]), true);

--- a/test/integration/utils/BaseIntegration.t.sol
+++ b/test/integration/utils/BaseIntegration.t.sol
@@ -63,7 +63,7 @@ abstract contract CollarBaseIntegrationTestConfig is Test, DeploymentHelper, Set
     function _setupConfig(
         address _swapRouter,
         address _cashAsset,
-        address _collateralAsset,
+        address _underlying,
         address _uniV3Pool,
         address whaleWallet,
         uint blockNumber,
@@ -85,23 +85,23 @@ abstract contract CollarBaseIntegrationTestConfig is Test, DeploymentHelper, Set
         user = user1;
         positionDuration = _positionDuration;
         offerLTV = _offerLTV;
-        _deployProtocolContracts(_cashAsset, _collateralAsset, pairName);
+        _deployProtocolContracts(_cashAsset, _underlying, pairName);
     }
 
-    function _deployProtocolContracts(address _cashAsset, address _collateralAsset, string memory pairName)
+    function _deployProtocolContracts(address _cashAsset, address _underlying, string memory pairName)
         internal
     {
         startHoax(owner);
         configHub = deployConfigHub(owner);
-        address[] memory collateralAssets = new address[](1);
-        collateralAssets[0] = _collateralAsset;
+        address[] memory underlyings = new address[](1);
+        underlyings[0] = _underlying;
         address[] memory cashAssets = new address[](1);
         cashAssets[0] = _cashAsset;
         setupConfigHub(
             configHub,
             SetupHelper.HubParams({
                 cashAssets: cashAssets,
-                collateralAssets: collateralAssets,
+                underlyings: underlyings,
                 minLTV: offerLTV,
                 maxLTV: offerLTV,
                 minDuration: positionDuration,
@@ -117,7 +117,7 @@ abstract contract CollarBaseIntegrationTestConfig is Test, DeploymentHelper, Set
             durations: durations,
             ltvs: ltvs,
             cashAsset: IERC20(_cashAsset),
-            collateralAsset: IERC20(_collateralAsset),
+            underlying: IERC20(_underlying),
             oracleFeeTier: 3000,
             swapFeeTier: 3000,
             twapWindow: 15 minutes,
@@ -126,23 +126,23 @@ abstract contract CollarBaseIntegrationTestConfig is Test, DeploymentHelper, Set
         pair = deployContractPair(configHub, pairConfig, owner);
         setupContractPair(configHub, pair);
         pair.cashAsset.forceApprove(address(pair.takerNFT), type(uint).max);
-        pair.collateralAsset.forceApprove(address(pair.takerNFT), type(uint).max);
+        pair.underlying.forceApprove(address(pair.takerNFT), type(uint).max);
     }
 
     function _fundWallets() internal {
         deal(address(pair.cashAsset), whale, bigNumber);
         deal(address(pair.cashAsset), user, bigNumber);
         deal(address(pair.cashAsset), provider, bigNumber);
-        deal(address(pair.collateralAsset), user, bigNumber);
-        deal(address(pair.collateralAsset), provider, bigNumber);
-        deal(address(pair.collateralAsset), whale, bigNumber);
+        deal(address(pair.underlying), user, bigNumber);
+        deal(address(pair.underlying), provider, bigNumber);
+        deal(address(pair.underlying), whale, bigNumber);
     }
 
     function _validateSetup(uint _duration, uint _offerLTV) internal view {
         assertEq(configHub.isValidCollarDuration(_duration), true);
         assertEq(configHub.isValidLTV(_offerLTV), true);
         assertEq(configHub.isSupportedCashAsset(address(pair.cashAsset)), true);
-        assertEq(configHub.isSupportedCollateralAsset(address(pair.collateralAsset)), true);
+        assertEq(configHub.isSupportedUnderlying(address(pair.underlying)), true);
         assertEq(configHub.canOpen(address(pair.takerNFT)), true);
         assertEq(configHub.canOpen(address(pair.providerNFT)), true);
     }

--- a/test/integration/utils/BaseIntegration.t.sol
+++ b/test/integration/utils/BaseIntegration.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.22;
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 import { ConfigHub } from "../../../src/ConfigHub.sol";
-import { ShortProviderNFT } from "../../../src/ShortProviderNFT.sol";
+import { CollarProviderNFT } from "../../../src/CollarProviderNFT.sol";
 import { OracleUniV3TWAP } from "../../../src/OracleUniV3TWAP.sol";
 import { CollarTakerNFT } from "../../../src/CollarTakerNFT.sol";
 import { LoansNFT, ILoansNFT } from "../../../src/LoansNFT.sol";

--- a/test/integration/utils/DeploymentLoader.sol
+++ b/test/integration/utils/DeploymentLoader.sol
@@ -46,7 +46,7 @@ abstract contract DeploymentLoader is DeploymentUtils {
         return (ConfigHub(configHubAddress), pairs);
     }
 
-    function getPairByAssets(address cashAsset, address collateralAsset)
+    function getPairByAssets(address cashAsset, address underlying)
         internal
         view
         returns (DeploymentHelper.AssetPairContracts memory pair)
@@ -55,13 +55,13 @@ abstract contract DeploymentLoader is DeploymentUtils {
             for (uint i = 0; i < deployedPairs.length; i++) {
                 if (
                     address(deployedPairs[i].cashAsset) == cashAsset
-                        && address(deployedPairs[i].collateralAsset) == collateralAsset
+                        && address(deployedPairs[i].underlying) == underlying
                 ) {
                     return deployedPairs[i];
                 }
             }
         } else {
-            (, pair) = getByAssetPair(cashAsset, collateralAsset);
+            (, pair) = getByAssetPair(cashAsset, underlying);
         }
     }
 }

--- a/test/integration/utils/PositionOperations.t.sol
+++ b/test/integration/utils/PositionOperations.t.sol
@@ -38,8 +38,8 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
         assertEq(address(position.providerNFT), address(pair.providerNFT));
         assertEq(position.duration, positionDuration);
         assertEq(position.expiration, block.timestamp + positionDuration);
-        assertEq(position.putStrikePrice, position.initialPrice * offerLTV / 10_000);
-        assert(position.callStrikePrice > position.initialPrice);
+        assertEq(position.putStrikePrice, position.startPrice * offerLTV / 10_000);
+        assert(position.callStrikePrice > position.startPrice);
         assert(position.takerLocked > 0);
         assert(position.providerLocked > 0);
         assertEq(position.settled, false);
@@ -60,7 +60,7 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
 
         // User withdrawal
         uint userBalanceBefore = pair.cashAsset.balanceOf(user);
-        pair.takerNFT.withdrawFromSettled(borrowId, user);
+        pair.takerNFT.withdrawFromSettled(borrowId);
         uint userBalanceAfter = pair.cashAsset.balanceOf(user);
         userWithdrawnAmount = userBalanceAfter - userBalanceBefore;
         vm.stopPrank();
@@ -68,7 +68,7 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
         // Provider withdrawal
         startHoax(provider);
         uint providerBalanceBefore = pair.cashAsset.balanceOf(provider);
-        pair.providerNFT.withdrawFromSettled(position.providerId, provider);
+        pair.providerNFT.withdrawFromSettled(position.providerId);
         uint providerBalanceAfter = pair.cashAsset.balanceOf(provider);
         providerWithdrawnAmount = providerBalanceAfter - providerBalanceBefore;
         vm.stopPrank();
@@ -79,8 +79,8 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
         pure
         returns (uint expectedUserWithdrawable, uint expectedProviderGain)
     {
-        uint lpPart = position.initialPrice - finalPrice;
-        uint putRange = position.initialPrice - position.putStrikePrice;
+        uint lpPart = position.startPrice - finalPrice;
+        uint putRange = position.startPrice - position.putStrikePrice;
         expectedProviderGain = position.takerLocked * lpPart / putRange;
         expectedUserWithdrawable = position.takerLocked - expectedProviderGain;
     }
@@ -90,8 +90,8 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
         pure
         returns (uint expectedUserWithdrawable, uint expectedProviderWithdrawable)
     {
-        uint userPart = finalPrice - position.initialPrice;
-        uint callRange = position.callStrikePrice - position.initialPrice;
+        uint userPart = finalPrice - position.startPrice;
+        uint callRange = position.callStrikePrice - position.startPrice;
         uint userGain = position.providerLocked * userPart / callRange;
         expectedUserWithdrawable = position.takerLocked + userGain;
         expectedProviderWithdrawable = position.providerLocked - userGain;

--- a/test/integration/utils/PositionOperations.t.sol
+++ b/test/integration/utils/PositionOperations.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.22;
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 import { CollarBaseIntegrationTestConfig, ILoansNFT } from "./BaseIntegration.t.sol";
-import { ShortProviderNFT } from "../../../src/ShortProviderNFT.sol";
+import { CollarProviderNFT } from "../../../src/CollarProviderNFT.sol";
 import { CollarTakerNFT } from "../../../src/CollarTakerNFT.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -251,7 +251,7 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
         callStrikePercents[3] = 13_000; // 130%
 
         for (uint i = 0; i < callStrikePercents.length; i++) {
-            ShortProviderNFT.LiquidityOffer memory offer = pair.providerNFT.getOffer(1 + i); // starts from 1
+            CollarProviderNFT.LiquidityOffer memory offer = pair.providerNFT.getOffer(1 + i); // starts from 1
             assertEq(offer.provider, provider);
             assertEq(offer.available, amountPerOffer);
             assertEq(offer.putStrikePercent, offerLTV);

--- a/test/integration/utils/PositionOperations.t.sol
+++ b/test/integration/utils/PositionOperations.t.sol
@@ -19,14 +19,14 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
         vm.stopPrank();
     }
 
-    function openTakerPositionAndCheckValues(uint collateralAmount, uint minCashAmount, uint offerId)
+    function openTakerPositionAndCheckValues(uint underlyingAmount, uint minCashAmount, uint offerId)
         internal
         returns (uint borrowId, CollarTakerNFT.TakerPosition memory position)
     {
         startHoax(user);
-        pair.collateralAsset.forceApprove(address(pair.loansContract), collateralAmount);
+        pair.underlying.forceApprove(address(pair.loansContract), underlyingAmount);
         (borrowId,,) = pair.loansContract.openLoan(
-            collateralAmount,
+            underlyingAmount,
             0,
             ILoansNFT.SwapParams(minCashAmount, address(pair.loansContract.defaultSwapper()), ""),
             offerId

--- a/test/integration/utils/PositionOperations.t.sol
+++ b/test/integration/utils/PositionOperations.t.sol
@@ -12,10 +12,10 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
     using SafeERC20 for IERC20;
 
-    function createProviderOffer(uint callStrikeDeviation, uint amount) internal returns (uint offerId) {
+    function createProviderOffer(uint callStrikePercent, uint amount) internal returns (uint offerId) {
         startHoax(provider);
         pair.cashAsset.forceApprove(address(pair.providerNFT), amount);
-        offerId = pair.providerNFT.createOffer(callStrikeDeviation, amount, offerLTV, positionDuration);
+        offerId = pair.providerNFT.createOffer(callStrikePercent, amount, offerLTV, positionDuration);
         vm.stopPrank();
     }
 
@@ -227,35 +227,35 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
     }
 
     function _setupOffers(uint amountPerOffer) internal {
-        uint[] memory callStrikeDeviations = new uint[](4);
-        callStrikeDeviations[0] = 11_000; // 110%
-        callStrikeDeviations[1] = 11_500; // 115%
-        callStrikeDeviations[2] = 12_000; // 120%
-        callStrikeDeviations[3] = 13_000; // 130%
+        uint[] memory callStrikePercents = new uint[](4);
+        callStrikePercents[0] = 11_000; // 110%
+        callStrikePercents[1] = 11_500; // 115%
+        callStrikePercents[2] = 12_000; // 120%
+        callStrikePercents[3] = 13_000; // 130%
 
         startHoax(provider);
         pair.cashAsset.forceApprove(address(pair.providerNFT), amountPerOffer * 4);
 
-        for (uint i = 0; i < callStrikeDeviations.length; i++) {
-            pair.providerNFT.createOffer(callStrikeDeviations[i], amountPerOffer, offerLTV, positionDuration);
+        for (uint i = 0; i < callStrikePercents.length; i++) {
+            pair.providerNFT.createOffer(callStrikePercents[i], amountPerOffer, offerLTV, positionDuration);
         }
 
         vm.stopPrank();
     }
 
     function _validateOfferSetup(uint amountPerOffer) internal view {
-        uint[] memory callStrikeDeviations = new uint[](4);
-        callStrikeDeviations[0] = 11_000; // 110%
-        callStrikeDeviations[1] = 11_500; // 115%
-        callStrikeDeviations[2] = 12_000; // 120%
-        callStrikeDeviations[3] = 13_000; // 130%
+        uint[] memory callStrikePercents = new uint[](4);
+        callStrikePercents[0] = 11_000; // 110%
+        callStrikePercents[1] = 11_500; // 115%
+        callStrikePercents[2] = 12_000; // 120%
+        callStrikePercents[3] = 13_000; // 130%
 
-        for (uint i = 0; i < callStrikeDeviations.length; i++) {
+        for (uint i = 0; i < callStrikePercents.length; i++) {
             ShortProviderNFT.LiquidityOffer memory offer = pair.providerNFT.getOffer(1 + i); // starts from 1
             assertEq(offer.provider, provider);
             assertEq(offer.available, amountPerOffer);
-            assertEq(offer.putStrikeDeviation, offerLTV);
-            assertEq(offer.callStrikeDeviation, callStrikeDeviations[i]);
+            assertEq(offer.putStrikePercent, offerLTV);
+            assertEq(offer.callStrikePercent, callStrikePercents[i]);
             assertEq(offer.duration, positionDuration);
         }
     }

--- a/test/integration/utils/PositionOperations.t.sol
+++ b/test/integration/utils/PositionOperations.t.sol
@@ -41,7 +41,7 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
         assertEq(position.putStrikePrice, position.initialPrice * offerLTV / 10_000);
         assert(position.callStrikePrice > position.initialPrice);
         assert(position.takerLocked > 0);
-        assert(position.callLockedCash > 0);
+        assert(position.providerLocked > 0);
         assertEq(position.settled, false);
         assertEq(position.withdrawable, 0);
     }
@@ -92,9 +92,9 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
     {
         uint userPart = finalPrice - position.initialPrice;
         uint callRange = position.callStrikePrice - position.initialPrice;
-        uint userGain = position.callLockedCash * userPart / callRange;
+        uint userGain = position.providerLocked * userPart / callRange;
         expectedUserWithdrawable = position.takerLocked + userGain;
-        expectedProviderWithdrawable = position.callLockedCash - userGain;
+        expectedProviderWithdrawable = position.providerLocked - userGain;
     }
 
     function checkPriceUnderPutStrikeValues(
@@ -116,7 +116,7 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
         assertEq(userWithdrawnAmount, 0);
         assertEq(userBalanceAfter, userCashBalanceBeforeSettle);
 
-        uint expectedProviderWithdrawal = position.takerLocked + position.callLockedCash;
+        uint expectedProviderWithdrawal = position.takerLocked + position.providerLocked;
         assertEq(providerWithdrawnAmount, expectedProviderWithdrawal);
         assertEq(providerBalanceAfter, providerCashBalanceBeforeSettle + expectedProviderWithdrawal);
     }
@@ -140,10 +140,10 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
         // and the provider gets the rest based on how close the price is to the put strike
         assertEq(userWithdrawnAmount, expectedUserWithdrawable);
         assertEq(userBalanceAfter, userCashBalanceBeforeSettle + expectedUserWithdrawable);
-        assertEq(providerWithdrawnAmount, expectedProviderGain + position.callLockedCash);
+        assertEq(providerWithdrawnAmount, expectedProviderGain + position.providerLocked);
         assertEq(
             providerBalanceAfter,
-            providerCashBalanceBeforeSettle + expectedProviderGain + position.callLockedCash
+            providerCashBalanceBeforeSettle + expectedProviderGain + position.providerLocked
         );
     }
 
@@ -162,7 +162,7 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
 
         // When price is up past call strike, the user receives all locked cash
         // and the provider receives nothing
-        uint expectedUserWithdrawal = position.takerLocked + position.callLockedCash;
+        uint expectedUserWithdrawal = position.takerLocked + position.providerLocked;
         assertEq(userWithdrawnAmount, expectedUserWithdrawal);
         assertEq(userBalanceAfter, userCashBalanceBeforeSettle + expectedUserWithdrawal);
 

--- a/test/integration/utils/PositionOperations.t.sol
+++ b/test/integration/utils/PositionOperations.t.sol
@@ -40,7 +40,7 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
         assertEq(position.expiration, block.timestamp + positionDuration);
         assertEq(position.putStrikePrice, position.initialPrice * offerLTV / 10_000);
         assert(position.callStrikePrice > position.initialPrice);
-        assert(position.putLockedCash > 0);
+        assert(position.takerLocked > 0);
         assert(position.callLockedCash > 0);
         assertEq(position.settled, false);
         assertEq(position.withdrawable, 0);
@@ -81,8 +81,8 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
     {
         uint lpPart = position.initialPrice - finalPrice;
         uint putRange = position.initialPrice - position.putStrikePrice;
-        expectedProviderGain = position.putLockedCash * lpPart / putRange;
-        expectedUserWithdrawable = position.putLockedCash - expectedProviderGain;
+        expectedProviderGain = position.takerLocked * lpPart / putRange;
+        expectedUserWithdrawable = position.takerLocked - expectedProviderGain;
     }
 
     function calculatePriceUpValues(CollarTakerNFT.TakerPosition memory position, uint finalPrice)
@@ -93,7 +93,7 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
         uint userPart = finalPrice - position.initialPrice;
         uint callRange = position.callStrikePrice - position.initialPrice;
         uint userGain = position.callLockedCash * userPart / callRange;
-        expectedUserWithdrawable = position.putLockedCash + userGain;
+        expectedUserWithdrawable = position.takerLocked + userGain;
         expectedProviderWithdrawable = position.callLockedCash - userGain;
     }
 
@@ -116,7 +116,7 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
         assertEq(userWithdrawnAmount, 0);
         assertEq(userBalanceAfter, userCashBalanceBeforeSettle);
 
-        uint expectedProviderWithdrawal = position.putLockedCash + position.callLockedCash;
+        uint expectedProviderWithdrawal = position.takerLocked + position.callLockedCash;
         assertEq(providerWithdrawnAmount, expectedProviderWithdrawal);
         assertEq(providerBalanceAfter, providerCashBalanceBeforeSettle + expectedProviderWithdrawal);
     }
@@ -162,7 +162,7 @@ abstract contract PositionOperationsTest is CollarBaseIntegrationTestConfig {
 
         // When price is up past call strike, the user receives all locked cash
         // and the provider receives nothing
-        uint expectedUserWithdrawal = position.putLockedCash + position.callLockedCash;
+        uint expectedUserWithdrawal = position.takerLocked + position.callLockedCash;
         assertEq(userWithdrawnAmount, expectedUserWithdrawal);
         assertEq(userBalanceAfter, userCashBalanceBeforeSettle + expectedUserWithdrawal);
 

--- a/test/integration/utils/PriceManipulation.t.sol
+++ b/test/integration/utils/PriceManipulation.t.sol
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
 pragma solidity 0.8.22;
 
 import "forge-std/Test.sol";

--- a/test/integration/utils/PriceManipulation.t.sol
+++ b/test/integration/utils/PriceManipulation.t.sol
@@ -26,7 +26,7 @@ abstract contract CollarIntegrationPriceManipulation is CollarBaseIntegrationTes
     using SafeERC20 for IERC20;
 
     function getCurrentAssetPrice() internal view returns (uint) {
-        address baseToken = address(pair.collateralAsset);
+        address baseToken = address(pair.underlying);
         address quoteToken = address(pair.cashAsset);
 
         address uniV3Factory = IPeripheryImmutableState(swapRouterAddress).factory();
@@ -93,11 +93,11 @@ abstract contract CollarIntegrationPriceManipulation is CollarBaseIntegrationTes
 
     function swapAsWhale(uint amount, bool swapCash) internal {
         uint currentPrice = getCurrentAssetPrice();
-        console.log("Current price of collateralAsset in cashAsset before swap: %d", currentPrice);
+        console.log("Current price of underlying in cashAsset before swap: %d", currentPrice);
 
         IV3SwapRouter.ExactInputSingleParams memory swapParams = IV3SwapRouter.ExactInputSingleParams({
-            tokenIn: swapCash ? address(pair.cashAsset) : address(pair.collateralAsset),
-            tokenOut: swapCash ? address(pair.collateralAsset) : address(pair.cashAsset),
+            tokenIn: swapCash ? address(pair.cashAsset) : address(pair.underlying),
+            tokenOut: swapCash ? address(pair.underlying) : address(pair.cashAsset),
             fee: 3000,
             recipient: whale,
             amountIn: amount,
@@ -111,6 +111,6 @@ abstract contract CollarIntegrationPriceManipulation is CollarBaseIntegrationTes
         vm.stopPrank();
 
         currentPrice = getCurrentAssetPrice();
-        console.log("Current price of collateralAsset in cashAsset after swap: %d", currentPrice);
+        console.log("Current price of underlying in cashAsset after swap: %d", currentPrice);
     }
 }

--- a/test/unit/BaseAssetPairTestSetup.sol
+++ b/test/unit/BaseAssetPairTestSetup.sol
@@ -10,7 +10,7 @@ import { MockOracleUniV3TWAP } from "../utils/MockOracleUniV3TWAP.sol";
 import { OracleUniV3TWAP } from "../../src/OracleUniV3TWAP.sol";
 import { ConfigHub } from "../../src/ConfigHub.sol";
 import { CollarTakerNFT } from "../../src/CollarTakerNFT.sol";
-import { ShortProviderNFT } from "../../src/ShortProviderNFT.sol";
+import { CollarProviderNFT } from "../../src/CollarProviderNFT.sol";
 import { Rolls } from "../../src/Rolls.sol";
 
 contract BaseAssetPairTestSetup is Test {
@@ -19,8 +19,8 @@ contract BaseAssetPairTestSetup is Test {
     ConfigHub configHub;
     MockOracleUniV3TWAP mockOracle;
     CollarTakerNFT takerNFT;
-    ShortProviderNFT providerNFT;
-    ShortProviderNFT providerNFT2;
+    CollarProviderNFT providerNFT;
+    CollarProviderNFT providerNFT2;
     Rolls rolls;
 
     address owner = makeAddr("owner");
@@ -65,16 +65,16 @@ contract BaseAssetPairTestSetup is Test {
         takerNFT = new CollarTakerNFT(
             owner, configHub, cashAsset, collateralAsset, mockOracle, "CollarTakerNFT", "TKRNFT"
         );
-        providerNFT = new ShortProviderNFT(
+        providerNFT = new CollarProviderNFT(
             owner, configHub, cashAsset, collateralAsset, address(takerNFT), "ProviderNFT", "PRVNFT"
         );
         // this is to avoid having the paired IDs being equal
-        providerNFT2 = new ShortProviderNFT(
+        providerNFT2 = new CollarProviderNFT(
             owner, configHub, cashAsset, collateralAsset, address(takerNFT), "ProviderNFT-2", "PRVNFT-2"
         );
         vm.label(address(mockOracle), "MockOracleUniV3TWAP");
         vm.label(address(takerNFT), "CollarTakerNFT");
-        vm.label(address(providerNFT), "ShortProviderNFT");
+        vm.label(address(providerNFT), "CollarProviderNFT");
 
         // asset pair periphery
         rolls = new Rolls(owner, takerNFT);

--- a/test/unit/BaseAssetPairTestSetup.sol
+++ b/test/unit/BaseAssetPairTestSetup.sol
@@ -15,7 +15,7 @@ import { Rolls } from "../../src/Rolls.sol";
 
 contract BaseAssetPairTestSetup is Test {
     TestERC20 cashAsset;
-    TestERC20 collateralAsset;
+    TestERC20 underlying;
     ConfigHub configHub;
     MockOracleUniV3TWAP mockOracle;
     CollarTakerNFT takerNFT;
@@ -37,10 +37,10 @@ contract BaseAssetPairTestSetup is Test {
     uint callStrikePercent = 12_000;
     uint protocolFeeAPR = 100;
 
-    uint collateralAmount = 1 ether;
+    uint underlyingAmount = 1 ether;
     uint largeAmount = 100_000 ether;
     uint twapPrice = 1000 ether;
-    uint swapCashAmount = (collateralAmount * twapPrice / 1e18);
+    uint swapCashAmount = (underlyingAmount * twapPrice / 1e18);
 
     int rollFee = 1 ether;
 
@@ -53,24 +53,24 @@ contract BaseAssetPairTestSetup is Test {
 
     function deployContracts() internal {
         cashAsset = new TestERC20("TestCash", "TestCash");
-        collateralAsset = new TestERC20("TestCollat", "TestCollat");
+        underlying = new TestERC20("TestCollat", "TestCollat");
         vm.label(address(cashAsset), "TestCash");
-        vm.label(address(collateralAsset), "TestCollat");
+        vm.label(address(underlying), "TestCollat");
 
         configHub = new ConfigHub(owner);
         vm.label(address(configHub), "ConfigHub");
 
         // asset pair contracts
-        mockOracle = new MockOracleUniV3TWAP(address(collateralAsset), address(cashAsset));
+        mockOracle = new MockOracleUniV3TWAP(address(underlying), address(cashAsset));
         takerNFT = new CollarTakerNFT(
-            owner, configHub, cashAsset, collateralAsset, mockOracle, "CollarTakerNFT", "TKRNFT"
+            owner, configHub, cashAsset, underlying, mockOracle, "CollarTakerNFT", "TKRNFT"
         );
         providerNFT = new CollarProviderNFT(
-            owner, configHub, cashAsset, collateralAsset, address(takerNFT), "ProviderNFT", "PRVNFT"
+            owner, configHub, cashAsset, underlying, address(takerNFT), "ProviderNFT", "PRVNFT"
         );
         // this is to avoid having the paired IDs being equal
         providerNFT2 = new CollarProviderNFT(
-            owner, configHub, cashAsset, collateralAsset, address(takerNFT), "ProviderNFT-2", "PRVNFT-2"
+            owner, configHub, cashAsset, underlying, address(takerNFT), "ProviderNFT-2", "PRVNFT-2"
         );
         vm.label(address(mockOracle), "MockOracleUniV3TWAP");
         vm.label(address(takerNFT), "CollarTakerNFT");
@@ -86,7 +86,7 @@ contract BaseAssetPairTestSetup is Test {
 
         // assets
         configHub.setCashAssetSupport(address(cashAsset), true);
-        configHub.setCollateralAssetSupport(address(collateralAsset), true);
+        configHub.setUnderlyingSupport(address(underlying), true);
         // terms
         configHub.setLTVRange(ltv, ltv);
         configHub.setCollarDurationRange(duration, duration);
@@ -109,10 +109,10 @@ contract BaseAssetPairTestSetup is Test {
     }
 
     function mintAssets() public {
-        collateralAsset.mint(user1, collateralAmount * 10);
+        underlying.mint(user1, underlyingAmount * 10);
         cashAsset.mint(user1, swapCashAmount * 10);
         cashAsset.mint(provider, largeAmount * 10);
-        collateralAsset.mint(supplier, largeAmount * 10);
+        underlying.mint(supplier, largeAmount * 10);
     }
 
     function expectRevertERC721Nonexistent(uint id) internal {

--- a/test/unit/BaseAssetPairTestSetup.sol
+++ b/test/unit/BaseAssetPairTestSetup.sol
@@ -34,7 +34,7 @@ contract BaseAssetPairTestSetup is Test {
 
     uint ltv = 9000;
     uint duration = 300;
-    uint callStrikeDeviation = 12_000;
+    uint callStrikePercent = 12_000;
     uint protocolFeeAPR = 100;
 
     uint collateralAmount = 1 ether;

--- a/test/unit/BaseManaged.all.t.sol
+++ b/test/unit/BaseManaged.all.t.sol
@@ -10,7 +10,7 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { TestERC20 } from "../utils/TestERC20.sol";
 import { MockOracleUniV3TWAP } from "../utils/MockOracleUniV3TWAP.sol";
 
-import {BaseManaged} from "../../src/base/BaseManaged.sol";
+import { BaseManaged } from "../../src/base/BaseManaged.sol";
 import { ConfigHub } from "../../src/ConfigHub.sol";
 import { CollarTakerNFT } from "../../src/CollarTakerNFT.sol";
 import { CollarProviderNFT } from "../../src/CollarProviderNFT.sol";

--- a/test/unit/CollarProviderNFT.t.sol
+++ b/test/unit/CollarProviderNFT.t.sol
@@ -144,7 +144,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         assertEq(address(newProviderNFT.owner()), owner);
         assertEq(address(newProviderNFT.configHub()), address(configHub));
         assertEq(address(newProviderNFT.cashAsset()), address(cashAsset));
-        assertEq(address(newProviderNFT.collateralAsset()), address(collateralAsset));
+        assertEq(newProviderNFT.collateralAsset(), address(collateralAsset));
         assertEq(address(newProviderNFT.taker()), takerContract);
         assertEq(newProviderNFT.MIN_CALL_STRIKE_BIPS(), 10_001);
         assertEq(newProviderNFT.MAX_CALL_STRIKE_BIPS(), 100_000);

--- a/test/unit/CollarProviderNFT.t.sol
+++ b/test/unit/CollarProviderNFT.t.sol
@@ -14,8 +14,6 @@ import { CollarProviderNFT, ICollarProviderNFT } from "../../src/CollarProviderN
 contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     address takerContract;
 
-    address recipient = makeAddr("recipient");
-
     uint putPercent = ltv;
 
     bool expectNonZeroFee = true;
@@ -106,13 +104,13 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         );
         vm.expectEmit(address(providerNFT));
         emit ICollarProviderNFT.PositionCreated(nextPosId, offerId, fee, expectedPosition);
-        (positionId, position) = providerNFT.mintFromOffer(offerId, positionAmount, takerId);
+        positionId = providerNFT.mintFromOffer(offerId, positionAmount, takerId);
+        position = providerNFT.getPosition(positionId);
 
         // Check position details
         assertEq(positionId, nextPosId);
-        assertEq(abi.encode(expectedPosition), abi.encode(position));
-        // check position view
-        assertEq(abi.encode(providerNFT.getPosition(positionId)), abi.encode(position));
+        // check the position (from the view)
+        assertEq(abi.encode(position), abi.encode(expectedPosition));
 
         // Check updated offer
         CollarProviderNFT.LiquidityOffer memory updatedOffer = providerNFT.getOffer(offerId);
@@ -174,17 +172,18 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
 
     function checkWithdraw(uint positionId, uint withdrawable) internal {
         uint providerBalance = cashAsset.balanceOf(provider);
-        uint recipientBalance = cashAsset.balanceOf(recipient);
         uint contractBalance = cashAsset.balanceOf(address(providerNFT));
 
         vm.startPrank(provider);
         vm.expectEmit(address(providerNFT));
-        emit ICollarProviderNFT.WithdrawalFromSettled(positionId, recipient, withdrawable);
-        providerNFT.withdrawFromSettled(positionId, recipient);
+        emit ICollarProviderNFT.WithdrawalFromSettled(positionId, withdrawable);
+        uint withdrawal = providerNFT.withdrawFromSettled(positionId);
+
+        // return value
+        assertEq(withdrawal, withdrawable);
 
         // Check balances
-        assertEq(cashAsset.balanceOf(recipient), recipientBalance + withdrawable);
-        assertEq(cashAsset.balanceOf(provider), providerBalance); // unchanged because sent to recipient
+        assertEq(cashAsset.balanceOf(provider), providerBalance + withdrawable);
         assertEq(cashAsset.balanceOf(address(providerNFT)), contractBalance - withdrawable);
 
         // Check position is burned
@@ -198,7 +197,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
 
     function checkCancelAndWithdraw(uint positionId, uint amountToMint) internal {
         uint providerBalance = cashAsset.balanceOf(provider);
-        uint recipientBalance = cashAsset.balanceOf(recipient);
+        uint takerBalance = cashAsset.balanceOf(takerContract);
         uint contractBalance = cashAsset.balanceOf(address(providerNFT));
 
         vm.startPrank(provider);
@@ -207,13 +206,14 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         vm.startPrank(takerContract);
         vm.expectEmit(address(providerNFT));
         emit ICollarProviderNFT.PositionCanceled(
-            positionId, recipient, amountToMint, providerNFT.getPosition(positionId).expiration
+            positionId, amountToMint, providerNFT.getPosition(positionId).expiration
         );
-        providerNFT.cancelAndWithdraw(positionId, recipient);
+        uint withdrawal = providerNFT.cancelAndWithdraw(positionId);
 
+        assertEq(withdrawal, amountToMint);
         // Check balances
-        assertEq(cashAsset.balanceOf(recipient), recipientBalance + amountToMint);
-        assertEq(cashAsset.balanceOf(provider), providerBalance); // unchanged because sent to recipient
+        assertEq(cashAsset.balanceOf(provider), providerBalance); // unchanged since they are not owner
+        assertEq(cashAsset.balanceOf(takerContract), takerBalance + amountToMint);
         assertEq(cashAsset.balanceOf(address(providerNFT)), contractBalance - amountToMint);
 
         // Check position is burned
@@ -453,8 +453,8 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         providerNFT.transferFrom(provider, takerContract, positionId);
         vm.startPrank(takerContract);
         vm.expectEmit(address(providerNFT));
-        emit ICollarProviderNFT.PositionCanceled(positionId, recipient, amountToMint, position.expiration);
-        providerNFT.cancelAndWithdraw(positionId, recipient);
+        emit ICollarProviderNFT.PositionCanceled(positionId, amountToMint, position.expiration);
+        providerNFT.cancelAndWithdraw(positionId);
     }
 
     function test_unpause() public {
@@ -502,7 +502,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         vm.startPrank(address(takerContract));
         for (uint i = 0; i < positionCount; i++) {
             uint amount = largeAmount;
-            (positionIds[i],) = providerNFT.mintFromOffer(offerId, amount, i);
+            positionIds[i] = providerNFT.mintFromOffer(offerId, amount, i);
         }
 
         CollarProviderNFT.LiquidityOffer memory updatedOffer = providerNFT.getOffer(offerId);
@@ -554,9 +554,10 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         // Withdraw from the settled position
         uint newOwnerBalance = cashAsset.balanceOf(newOwner);
         vm.startPrank(newOwner);
-        providerNFT.withdrawFromSettled(positionId, newOwner);
+        uint withdrwal = providerNFT.withdrawFromSettled(positionId);
 
         // Check that the withdrawal was successful
+        assertEq(withdrwal, position.principal + uint(positionChange));
         assertEq(cashAsset.balanceOf(newOwner) - newOwnerBalance, position.principal + uint(positionChange));
 
         // Check that the position is burned after withdrawal
@@ -593,15 +594,15 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         providerNFT.settlePosition(0, 0);
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
-        providerNFT.withdrawFromSettled(0, address(0));
+        providerNFT.withdrawFromSettled(0);
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
-        providerNFT.cancelAndWithdraw(0, address(0));
+        providerNFT.cancelAndWithdraw(0);
 
         // transfers are paused
         vm.startPrank(provider);
         vm.expectRevert(Pausable.EnforcedPause.selector);
-        providerNFT.transferFrom(provider, recipient, positionId);
+        providerNFT.transferFrom(provider, user1, positionId);
     }
 
     function test_revert_createOffer_invalidCallStrike() public {
@@ -752,7 +753,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         vm.startPrank(provider);
         providerNFT.transferFrom(provider, takerContract, positionId);
         vm.startPrank(address(takerContract));
-        providerNFT.cancelAndWithdraw(positionId, provider);
+        providerNFT.cancelAndWithdraw(positionId);
 
         // can't settle twice
         vm.expectRevert("already settled");
@@ -764,17 +765,17 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
 
         // not yet minted
         expectRevertERC721Nonexistent(positionId + 1);
-        providerNFT.withdrawFromSettled(positionId + 1, provider);
+        providerNFT.withdrawFromSettled(positionId + 1);
 
         // not owner
         vm.startPrank(address(0xdead));
         vm.expectRevert("not position owner");
-        providerNFT.withdrawFromSettled(positionId, provider);
+        providerNFT.withdrawFromSettled(positionId);
 
         // not settled
         vm.startPrank(provider);
         vm.expectRevert("not settled");
-        providerNFT.withdrawFromSettled(positionId, provider);
+        providerNFT.withdrawFromSettled(positionId);
     }
 
     function test_revert_cancelAndWithdraw() public {
@@ -782,13 +783,13 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
 
         vm.startPrank(address(0xdead));
         vm.expectRevert("unauthorized taker contract");
-        providerNFT.cancelAndWithdraw(positionId, provider);
+        providerNFT.cancelAndWithdraw(positionId);
 
         vm.startPrank(owner);
         configHub.setCanOpen(takerContract, true);
         vm.startPrank(address(takerContract));
         vm.expectRevert("caller does not own token");
-        providerNFT.cancelAndWithdraw(positionId, provider);
+        providerNFT.cancelAndWithdraw(positionId);
 
         skip(duration);
         providerNFT.settlePosition(positionId, 0);
@@ -798,6 +799,6 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         providerNFT.transferFrom(provider, takerContract, positionId);
         vm.startPrank(address(takerContract));
         vm.expectRevert("already settled");
-        providerNFT.cancelAndWithdraw(positionId, provider);
+        providerNFT.cancelAndWithdraw(positionId);
     }
 }

--- a/test/unit/CollarProviderNFT.t.sol
+++ b/test/unit/CollarProviderNFT.t.sol
@@ -129,22 +129,16 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     function test_constructor() public {
         vm.expectEmit();
         emit ICollarProviderNFT.CollarProviderNFTCreated(
-            address(cashAsset), address(collateralAsset), address(takerContract)
+            address(cashAsset), address(underlying), address(takerContract)
         );
         CollarProviderNFT newProviderNFT = new CollarProviderNFT(
-            owner,
-            configHub,
-            cashAsset,
-            collateralAsset,
-            address(takerContract),
-            "NewCollarProviderNFT",
-            "NPRVNFT"
+            owner, configHub, cashAsset, underlying, address(takerContract), "NewCollarProviderNFT", "NPRVNFT"
         );
 
         assertEq(address(newProviderNFT.owner()), owner);
         assertEq(address(newProviderNFT.configHub()), address(configHub));
         assertEq(address(newProviderNFT.cashAsset()), address(cashAsset));
-        assertEq(newProviderNFT.collateralAsset(), address(collateralAsset));
+        assertEq(newProviderNFT.underlying(), address(underlying));
         assertEq(address(newProviderNFT.taker()), takerContract);
         assertEq(newProviderNFT.MIN_CALL_STRIKE_BIPS(), 10_001);
         assertEq(newProviderNFT.MAX_CALL_STRIKE_BIPS(), 100_000);
@@ -638,7 +632,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         providerNFT.createOffer(callStrikePercent, largeAmount, putPercent, duration);
         configHub.setCashAssetSupport(address(cashAsset), true);
 
-        configHub.setCollateralAssetSupport(address(collateralAsset), false);
+        configHub.setUnderlyingSupport(address(underlying), false);
         vm.expectRevert("unsupported asset");
         providerNFT.createOffer(callStrikePercent, largeAmount, putPercent, duration);
     }
@@ -703,7 +697,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
 
         vm.startPrank(owner);
         configHub.setCashAssetSupport(address(cashAsset), true);
-        configHub.setCollateralAssetSupport(address(collateralAsset), false);
+        configHub.setUnderlyingSupport(address(underlying), false);
         vm.startPrank(address(takerContract));
         vm.expectRevert("unsupported asset");
         providerNFT.mintFromOffer(offerId, largeAmount / 2, 0);

--- a/test/unit/CollarTakerNFT.t.sol
+++ b/test/unit/CollarTakerNFT.t.sol
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
 pragma solidity 0.8.22;
 
 import "forge-std/Test.sol";
@@ -63,7 +57,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
             providerId: expectedProviderId,
             duration: duration,
             expiration: block.timestamp + duration,
-            initialPrice: twapPrice,
+            startPrice: twapPrice,
             putStrikePrice: putStrikePrice,
             callStrikePrice: callStrikePrice,
             takerLocked: takerLocked,
@@ -177,8 +171,8 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
     function checkWithdrawFromSettled(uint takerId, uint expectedTakerOut) public {
         uint cashBalanceBefore = cashAsset.balanceOf(user1);
         vm.expectEmit(address(takerNFT));
-        emit ICollarTakerNFT.WithdrawalFromSettled(takerId, user1, expectedTakerOut);
-        uint withdrawal = takerNFT.withdrawFromSettled(takerId, user1);
+        emit ICollarTakerNFT.WithdrawalFromSettled(takerId, expectedTakerOut);
+        uint withdrawal = takerNFT.withdrawFromSettled(takerId);
         assertEq(withdrawal, expectedTakerOut);
         assertEq(cashAsset.balanceOf(user1), cashBalanceBefore + expectedTakerOut);
         CollarTakerNFT.TakerPosition memory position = takerNFT.getPosition(takerId);
@@ -240,6 +234,17 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         newOracle.setHistoricalAssetPrice(block.timestamp, 0);
         vm.expectRevert("invalid price");
         new CollarTakerNFT(owner, configHub, cashAsset, underlying, newOracle, "NewCollarTakerNFT", "NBPNFT");
+
+        newOracle.setHistoricalAssetPrice(block.timestamp, 1);
+        vm.mockCallRevert(
+            address(newOracle), abi.encodeCall(newOracle.pastPriceWithFallback, (uint32(block.timestamp))), ""
+        );
+        vm.expectRevert(new bytes(0));
+        new CollarTakerNFT(owner, configHub, cashAsset, underlying, newOracle, "NewCollarTakerNFT", "NBPNFT");
+
+        vm.mockCallRevert(address(newOracle), abi.encodeCall(newOracle.BASE_TOKEN_AMOUNT, ()), "");
+        vm.expectRevert(new bytes(0));
+        new CollarTakerNFT(owner, configHub, cashAsset, underlying, newOracle, "NewCollarTakerNFT", "NBPNFT");
     }
 
     function test_pausableMethods() public {
@@ -259,11 +264,11 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
 
         // Try to withdraw from settled while paused
         vm.expectRevert(Pausable.EnforcedPause.selector);
-        takerNFT.withdrawFromSettled(0, address(this));
+        takerNFT.withdrawFromSettled(0);
 
         // Try to cancel a paired position while paused
         vm.expectRevert(Pausable.EnforcedPause.selector);
-        takerNFT.cancelPairedPosition(0, address(this));
+        takerNFT.cancelPairedPosition(0);
 
         // transfers are paused
         vm.startPrank(user1);
@@ -361,6 +366,20 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         takerNFT.openPairedPosition(takerLocked, providerNFT, 1000);
     }
 
+    function test_openPairedPosition_expirationMistmatch() public {
+        createOffer();
+        startHoax(user1);
+        CollarProviderNFT.ProviderPosition memory badExpiryPosition;
+        badExpiryPosition.expiration = block.timestamp + duration + 1;
+        vm.mockCall(
+            address(providerNFT),
+            abi.encodeCall(providerNFT.getPosition, (providerNFT.nextPositionId())),
+            abi.encode(badExpiryPosition)
+        );
+        vm.expectRevert("expiration mismatch");
+        takerNFT.openPairedPosition(takerLocked, providerNFT, offerId);
+    }
+
     function test_openPairedPositionBadCashAssetMismatch() public {
         createOffer();
         vm.startPrank(owner);
@@ -398,7 +417,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         updatePrice(991);
         startHoax(user1);
         cashAsset.approve(address(takerNFT), takerLocked);
-        vm.expectRevert("strike prices aren't different");
+        vm.expectRevert("strike prices not different");
         takerNFT.openPairedPosition(takerLocked, providerNFT, offerId);
     }
 
@@ -486,23 +505,6 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         checkWithdrawFromSettled(takerId, takerLocked + providerLocked);
     }
 
-    function test_withdrawRecipient() public {
-        uint expectedTakerOut = takerLocked;
-        uint takerId = createAndSettlePosition(twapPrice, 0);
-        // non owner recipient
-        address recipient = address(0x123);
-        uint cashBalanceBefore = cashAsset.balanceOf(recipient);
-        uint cashBalanceUserBefore = cashAsset.balanceOf(user1);
-        vm.expectEmit(address(takerNFT));
-        emit ICollarTakerNFT.WithdrawalFromSettled(takerId, recipient, expectedTakerOut);
-        uint withdrawal = takerNFT.withdrawFromSettled(takerId, recipient);
-        assertEq(withdrawal, expectedTakerOut);
-        assertEq(cashAsset.balanceOf(recipient), cashBalanceBefore + expectedTakerOut);
-        assertEq(cashAsset.balanceOf(user1), cashBalanceUserBefore);
-        CollarTakerNFT.TakerPosition memory position = takerNFT.getPosition(takerId);
-        assertEq(position.withdrawable, 0);
-    }
-
     function test_settlePairedPosition_NonExistentPosition() public {
         vm.expectRevert("position doesn't exist");
         takerNFT.settlePairedPosition(999); // Use a position ID that doesn't exist
@@ -541,7 +543,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         // Try to withdraw with a different address
         startHoax(address(0xdead));
         vm.expectRevert("not position owner");
-        takerNFT.withdrawFromSettled(takerId, address(0xdead));
+        takerNFT.withdrawFromSettled(takerId);
     }
 
     function test_withdrawFromSettled_NotSettled() public {
@@ -550,17 +552,16 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         // Try to withdraw before settling
         startHoax(user1);
         vm.expectRevert("not settled");
-        takerNFT.withdrawFromSettled(takerId, user1);
+        takerNFT.withdrawFromSettled(takerId);
     }
 
     function test_cancelPairedPosition() public {
         (uint takerId, uint providerNFTId) = checkOpenPairedPosition();
 
-        address recipient = address(123);
-
         uint userCashBefore = cashAsset.balanceOf(user1);
         uint providerCashBefore = cashAsset.balanceOf(provider);
-        uint recipientCashBefore = cashAsset.balanceOf(recipient);
+
+        uint expectedWithdrawal = takerLocked + providerLocked;
 
         startHoax(user1);
         takerNFT.safeTransferFrom(user1, provider, takerId);
@@ -569,9 +570,11 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         providerNFT.approve(address(takerNFT), providerNFTId);
         vm.expectEmit(address(takerNFT));
         emit ICollarTakerNFT.PairedPositionCanceled(
-            takerId, address(providerNFT), providerNFTId, recipient, takerLocked, block.timestamp + duration
+            takerId, address(providerNFT), providerNFTId, expectedWithdrawal, block.timestamp + duration
         );
-        takerNFT.cancelPairedPosition(takerId, recipient);
+        uint withdrawal = takerNFT.cancelPairedPosition(takerId);
+
+        assertEq(withdrawal, expectedWithdrawal);
 
         // view
         CollarTakerNFT.TakerPosition memory position = takerNFT.getPosition(takerId);
@@ -579,9 +582,8 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         assertEq(position.withdrawable, 0);
 
         // balances
-        assertEq(cashAsset.balanceOf(recipient), recipientCashBefore + takerLocked + providerLocked);
         assertEq(cashAsset.balanceOf(user1), userCashBefore);
-        assertEq(cashAsset.balanceOf(provider), providerCashBefore);
+        assertEq(cashAsset.balanceOf(provider), providerCashBefore + expectedWithdrawal);
     }
 
     function test_cancelPairedPosition_NotOwnerOfTakerID() public {
@@ -590,7 +592,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         // Try to cancel with a different address
         startHoax(address(0xdead));
         vm.expectRevert("not owner of taker ID");
-        takerNFT.cancelPairedPosition(takerId, address(0xdead));
+        takerNFT.cancelPairedPosition(takerId);
     }
 
     function test_cancelPairedPosition_NotOwnerOfProviderID() public {
@@ -603,7 +605,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         // Try to cancel with the new taker NFT owner
         startHoax(address(0xbeef));
         vm.expectRevert("not owner of provider ID");
-        takerNFT.cancelPairedPosition(takerId, address(0xbeef));
+        takerNFT.cancelPairedPosition(takerId);
     }
 
     function test_cancelPairedPosition_AlreadySettled() public {
@@ -617,7 +619,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         takerNFT.safeTransferFrom(user1, provider, takerId);
         startHoax(provider);
         vm.expectRevert("already settled");
-        takerNFT.cancelPairedPosition(takerId, user1);
+        takerNFT.cancelPairedPosition(takerId);
     }
 
     function test_setOracle() public {
@@ -664,5 +666,16 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         newOracle.setHistoricalAssetPrice(block.timestamp, 0);
         vm.expectRevert("invalid price");
         takerNFT.setOracle(newOracle);
+
+        newOracle.setHistoricalAssetPrice(block.timestamp, 1);
+        vm.mockCallRevert(
+            address(newOracle), abi.encodeCall(newOracle.pastPriceWithFallback, (uint32(block.timestamp))), ""
+        );
+        vm.expectRevert(new bytes(0));
+        new CollarTakerNFT(owner, configHub, cashAsset, underlying, newOracle, "NewCollarTakerNFT", "NBPNFT");
+
+        vm.mockCallRevert(address(newOracle), abi.encodeCall(newOracle.BASE_TOKEN_AMOUNT, ()), "");
+        vm.expectRevert(new bytes(0));
+        new CollarTakerNFT(owner, configHub, cashAsset, underlying, newOracle, "NewCollarTakerNFT", "NBPNFT");
     }
 }

--- a/test/unit/CollarTakerNFT.t.sol
+++ b/test/unit/CollarTakerNFT.t.sol
@@ -17,8 +17,8 @@ import { BaseAssetPairTestSetup, MockOracleUniV3TWAP } from "./BaseAssetPairTest
 
 import { CollarTakerNFT, ICollarTakerNFT } from "../../src/CollarTakerNFT.sol";
 import { ICollarTakerNFT } from "../../src/interfaces/ICollarTakerNFT.sol";
-import { ShortProviderNFT } from "../../src/ShortProviderNFT.sol";
-import { IShortProviderNFT } from "../../src/interfaces/IShortProviderNFT.sol";
+import { CollarProviderNFT } from "../../src/CollarProviderNFT.sol";
+import { ICollarProviderNFT } from "../../src/interfaces/ICollarProviderNFT.sol";
 
 contract CollarTakerNFTTest is BaseAssetPairTestSetup {
     uint takerLocked = 1000 ether;
@@ -34,11 +34,11 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
 
         uint expectedOfferId = providerNFT.nextPositionId();
         vm.expectEmit(address(providerNFT));
-        emit IShortProviderNFT.OfferCreated(
+        emit ICollarProviderNFT.OfferCreated(
             provider, ltv, duration, callStrikePercent, largeAmount, expectedOfferId
         );
         offerId = providerNFT.createOffer(callStrikePercent, largeAmount, ltv, duration);
-        ShortProviderNFT.LiquidityOffer memory offer = providerNFT.getOffer(offerId);
+        CollarProviderNFT.LiquidityOffer memory offer = providerNFT.getOffer(offerId);
         assertEq(offer.callStrikePercent, callStrikePercent);
         assertEq(offer.available, largeAmount);
         assertEq(offer.provider, provider);
@@ -85,7 +85,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         assertEq(abi.encode(takerPos), abi.encode(expectedTakerPos));
 
         // provider position
-        ShortProviderNFT.ProviderPosition memory providerPos = providerNFT.getPosition(providerNFTId);
+        CollarProviderNFT.ProviderPosition memory providerPos = providerNFT.getPosition(providerNFTId);
         assertEq(providerPos.expiration, block.timestamp + duration);
         assertEq(providerPos.principal, providerLocked);
         assertEq(providerPos.putStrikePercent, ltv);
@@ -142,7 +142,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
 
         startHoax(user1);
         vm.expectEmit(address(providerNFT));
-        emit IShortProviderNFT.PositionSettled(providerNFTId, expectedProviderChange, expectedProviderOut);
+        emit ICollarProviderNFT.PositionSettled(providerNFTId, expectedProviderChange, expectedProviderOut);
         vm.expectEmit(address(takerNFT));
         emit ICollarTakerNFT.PairedPositionSettled(
             takerId,
@@ -169,7 +169,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         assertEq(takerPosAfter.settled, true);
         assertEq(takerPosAfter.withdrawable, expectedTakerOut);
 
-        ShortProviderNFT.ProviderPosition memory providerPosAfter = providerNFT.getPosition(providerNFTId);
+        CollarProviderNFT.ProviderPosition memory providerPosAfter = providerNFT.getPosition(providerNFTId);
         assertEq(providerPosAfter.settled, true);
         assertEq(providerPosAfter.withdrawable, expectedProviderOut);
     }
@@ -368,7 +368,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         createOffer();
         vm.startPrank(owner);
         configHub.setCashAssetSupport(address(collateralAsset), true);
-        ShortProviderNFT providerNFTBad = new ShortProviderNFT(
+        CollarProviderNFT providerNFTBad = new CollarProviderNFT(
             owner,
             configHub,
             collateralAsset,
@@ -388,7 +388,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         createOffer();
         vm.startPrank(owner);
         configHub.setCollateralAssetSupport(address(cashAsset), true);
-        ShortProviderNFT providerNFTBad = new ShortProviderNFT(
+        CollarProviderNFT providerNFTBad = new CollarProviderNFT(
             owner, configHub, cashAsset, cashAsset, address(takerNFT), "CollarTakerNFTBad", "BRWTSTBAD"
         );
         configHub.setCanOpen(address(providerNFTBad), true);

--- a/test/unit/CollarTakerNFT.t.sol
+++ b/test/unit/CollarTakerNFT.t.sol
@@ -202,7 +202,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         assertEq(takerNFT.pendingOwner(), address(0));
         assertEq(address(takerNFT.configHub()), address(configHub));
         assertEq(address(takerNFT.cashAsset()), address(cashAsset));
-        assertEq(address(takerNFT.collateralAsset()), address(collateralAsset));
+        assertEq(takerNFT.collateralAsset(), address(collateralAsset));
         assertEq(address(takerNFT.oracle()), address(mockOracle));
         assertEq(takerNFT.VERSION(), "0.2.0");
         assertEq(takerNFT.name(), "NewCollarTakerNFT");

--- a/test/unit/CollarTakerNFT.t.sol
+++ b/test/unit/CollarTakerNFT.t.sol
@@ -35,16 +35,16 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         uint expectedOfferId = providerNFT.nextPositionId();
         vm.expectEmit(address(providerNFT));
         emit IShortProviderNFT.OfferCreated(
-            provider, ltv, duration, callStrikeDeviation, largeAmount, expectedOfferId
+            provider, ltv, duration, callStrikePercent, largeAmount, expectedOfferId
         );
-        offerId = providerNFT.createOffer(callStrikeDeviation, largeAmount, ltv, duration);
+        offerId = providerNFT.createOffer(callStrikePercent, largeAmount, ltv, duration);
         ShortProviderNFT.LiquidityOffer memory offer = providerNFT.getOffer(offerId);
-        assertEq(offer.callStrikeDeviation, callStrikeDeviation);
+        assertEq(offer.callStrikePercent, callStrikePercent);
         assertEq(offer.available, largeAmount);
         assertEq(offer.provider, provider);
         assertEq(offer.duration, duration);
-        assertEq(offer.callStrikeDeviation, callStrikeDeviation);
-        assertEq(offer.putStrikeDeviation, ltv);
+        assertEq(offer.callStrikePercent, callStrikePercent);
+        assertEq(offer.putStrikePercent, ltv);
     }
 
     function checkOpenPairedPosition() internal returns (uint takerId, uint providerNFTId) {
@@ -56,7 +56,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         // expected values
         uint expectedTakerId = takerNFT.nextPositionId();
         uint expectedProviderId = providerNFT.nextPositionId();
-        uint _providerLocked = checkCalculateProviderLocked(takerLocked, ltv, callStrikeDeviation);
+        uint _providerLocked = checkCalculateProviderLocked(takerLocked, ltv, callStrikePercent);
 
         ICollarTakerNFT.TakerPosition memory expectedTakerPos = ICollarTakerNFT.TakerPosition({
             providerNFT: providerNFT,
@@ -88,8 +88,8 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         ShortProviderNFT.ProviderPosition memory providerPos = providerNFT.getPosition(providerNFTId);
         assertEq(providerPos.expiration, block.timestamp + duration);
         assertEq(providerPos.principal, providerLocked);
-        assertEq(providerPos.putStrikeDeviation, ltv);
-        assertEq(providerPos.callStrikeDeviation, callStrikeDeviation);
+        assertEq(providerPos.putStrikePercent, ltv);
+        assertEq(providerPos.callStrikePercent, callStrikePercent);
         assertEq(providerPos.settled, false);
         assertEq(providerPos.withdrawable, 0);
     }
@@ -318,7 +318,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
 
     /**
      * openPaired validation errors:
-     * and create offer doesnt allow you to put a put strike deviation > 10000
+     * and create offer doesnt allow you to put a put strike percent > 10000
      */
     function test_openPairedPositionUnsupportedCashAsset() public {
         createOffer();
@@ -401,7 +401,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
     function test_openPairedPositionStrikePricesArentDifferent() public {
         vm.startPrank(owner);
         configHub.setLTVRange(9990, 9990);
-        callStrikeDeviation = 10_010;
+        callStrikePercent = 10_010;
         ltv = 9990;
         createOffer();
         updatePrice(991);

--- a/test/unit/ConfigHub.t.sol
+++ b/test/unit/ConfigHub.t.sol
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
 pragma solidity 0.8.22;
 
 import "forge-std/Test.sol";

--- a/test/unit/ConfigHub.t.sol
+++ b/test/unit/ConfigHub.t.sol
@@ -11,7 +11,7 @@ import "forge-std/Test.sol";
 import { TestERC20 } from "../utils/TestERC20.sol";
 import { ConfigHub, IConfigHub } from "../../src/ConfigHub.sol";
 import { ICollarTakerNFT } from "../../src/interfaces/ICollarTakerNFT.sol";
-import { IShortProviderNFT } from "../../src/interfaces/IShortProviderNFT.sol";
+import { ICollarProviderNFT } from "../../src/interfaces/ICollarProviderNFT.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 contract ConfigHubTest is Test {

--- a/test/unit/ConfigHub.t.sol
+++ b/test/unit/ConfigHub.t.sol
@@ -42,8 +42,8 @@ contract ConfigHubTest is Test {
         assertEq(configHub.owner(), owner);
         assertEq(configHub.pendingOwner(), address(0));
         assertEq(configHub.VERSION(), "0.2.0");
-        assertEq(configHub.MIN_CONFIGURABLE_LTV(), 1000);
-        assertEq(configHub.MAX_CONFIGURABLE_LTV(), 9999);
+        assertEq(configHub.MIN_CONFIGURABLE_LTV_BIPS(), 1000);
+        assertEq(configHub.MAX_CONFIGURABLE_LTV_BIPS(), 9999);
         assertEq(configHub.MIN_CONFIGURABLE_DURATION(), 300);
         assertEq(configHub.MAX_CONFIGURABLE_DURATION(), 5 * 365 days);
         assertEq(configHub.pauseGuardian(), address(0));

--- a/test/unit/ConfigHub.t.sol
+++ b/test/unit/ConfigHub.t.sol
@@ -68,7 +68,7 @@ contract ConfigHubTest is Test {
         configHub.setCollarDurationRange(0, 0);
 
         vm.expectRevert(user1NotAuthorized);
-        configHub.setCollateralAssetSupport(address(0), true);
+        configHub.setUnderlyingSupport(address(0), true);
 
         vm.expectRevert(user1NotAuthorized);
         configHub.setCashAssetSupport(address(0), true);
@@ -113,18 +113,18 @@ contract ConfigHubTest is Test {
         assertFalse(configHub.isSupportedCashAsset(address(token1)));
     }
 
-    function test_addSupportedCollateralAsset() public {
+    function test_addSupportedUnderlying() public {
         startHoax(owner);
-        assertFalse(configHub.isSupportedCollateralAsset(address(token1)));
-        configHub.setCollateralAssetSupport(address(token1), true);
-        assertTrue(configHub.isSupportedCollateralAsset(address(token1)));
+        assertFalse(configHub.isSupportedUnderlying(address(token1)));
+        configHub.setUnderlyingSupport(address(token1), true);
+        assertTrue(configHub.isSupportedUnderlying(address(token1)));
     }
 
-    function test_removeSupportedCollateralAsset() public {
+    function test_removeSupportedUnderlying() public {
         startHoax(owner);
-        configHub.setCollateralAssetSupport(address(token1), true);
-        configHub.setCollateralAssetSupport(address(token1), false);
-        assertFalse(configHub.isSupportedCollateralAsset(address(token1)));
+        configHub.setUnderlyingSupport(address(token1), true);
+        configHub.setUnderlyingSupport(address(token1), false);
+        assertFalse(configHub.isSupportedUnderlying(address(token1)));
     }
 
     function test_isValidDuration() public {

--- a/test/unit/EmergencyAdmin.all.t.sol
+++ b/test/unit/EmergencyAdmin.all.t.sol
@@ -13,7 +13,7 @@ import { MockOracleUniV3TWAP } from "../utils/MockOracleUniV3TWAP.sol";
 import { BaseEmergencyAdmin } from "../../src/base/BaseEmergencyAdmin.sol";
 import { ConfigHub } from "../../src/ConfigHub.sol";
 import { CollarTakerNFT } from "../../src/CollarTakerNFT.sol";
-import { ShortProviderNFT } from "../../src/ShortProviderNFT.sol";
+import { CollarProviderNFT } from "../../src/CollarProviderNFT.sol";
 import { EscrowSupplierNFT } from "../../src/EscrowSupplierNFT.sol";
 import { LoansNFT } from "../../src/LoansNFT.sol";
 import { Rolls } from "../../src/Rolls.sol";
@@ -215,7 +215,7 @@ contract BaseEmergencyAdminMockTest is BaseEmergencyAdminTestBase {
 contract ProviderNFTEmergencyAdminTest is BaseEmergencyAdminTestBase {
     function setupTestedContract() internal override {
         testedContract =
-            new ShortProviderNFT(owner, configHub, erc20, erc20, address(0), "ProviderNFT", "ProviderNFT");
+            new CollarProviderNFT(owner, configHub, erc20, erc20, address(0), "ProviderNFT", "ProviderNFT");
     }
 }
 

--- a/test/unit/EscrowSupplierNFT.effects.t.sol
+++ b/test/unit/EscrowSupplierNFT.effects.t.sol
@@ -24,7 +24,7 @@ contract BaseEscrowSupplierNFTTest is BaseAssetPairTestSetup {
 
     function setUp() public override {
         super.setUp();
-        asset = collateralAsset;
+        asset = underlying;
         escrowNFT = new EscrowSupplierNFT(owner, configHub, asset, "ES Test", "ES Test");
 
         vm.startPrank(owner);

--- a/test/unit/EscrowSupplierNFT.reverts.t.sol
+++ b/test/unit/EscrowSupplierNFT.reverts.t.sol
@@ -32,7 +32,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
 
         // bad asset
         vm.startPrank(owner);
-        configHub.setCollateralAssetSupport(address(asset), false);
+        configHub.setUnderlyingSupport(address(asset), false);
         vm.startPrank(supplier1);
         vm.expectRevert("unsupported asset");
         escrowNFT.createOffer(largeAmount, duration, interestAPR, gracePeriod, lateFeeAPR);
@@ -70,7 +70,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
 
         // bad asset
         vm.startPrank(owner);
-        configHub.setCollateralAssetSupport(address(asset), false);
+        configHub.setUnderlyingSupport(address(asset), false);
         vm.startPrank(loans);
         vm.expectRevert("unsupported asset");
         escrowNFT.startEscrow(offerId, largeAmount, 1 ether, 1000);
@@ -105,7 +105,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
 
         // bad asset
         vm.startPrank(owner);
-        configHub.setCollateralAssetSupport(address(asset), false);
+        configHub.setUnderlyingSupport(address(asset), false);
         vm.startPrank(loans);
         vm.expectRevert("unsupported asset");
         escrowNFT.switchEscrow(escrowId, newOfferId, 1000, minFee);

--- a/test/unit/Loans.admin.t.sol
+++ b/test/unit/Loans.admin.t.sol
@@ -10,7 +10,7 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 import { LoansNFT, ILoansNFT } from "../../src/LoansNFT.sol";
 import { CollarTakerNFT } from "../../src/CollarTakerNFT.sol";
-import { ShortProviderNFT } from "../../src/ShortProviderNFT.sol";
+import { CollarProviderNFT } from "../../src/CollarProviderNFT.sol";
 import { Rolls } from "../../src/Rolls.sol";
 
 import {
@@ -32,7 +32,7 @@ contract LoansAdminTest is LoansTestBase {
         loans.setKeeper(keeper);
 
         vm.expectRevert(abi.encodeWithSelector(selector, user1));
-        loans.setContracts(Rolls(address(0)), ShortProviderNFT(address(0)), EscrowSupplierNFT(address(0)));
+        loans.setContracts(Rolls(address(0)), CollarProviderNFT(address(0)), EscrowSupplierNFT(address(0)));
 
         vm.expectRevert(abi.encodeWithSelector(selector, user1));
         loans.setSwapperAllowed(address(0), true, true);
@@ -56,8 +56,8 @@ contract LoansAdminTest is LoansTestBase {
         assertEq(address(loans.currentEscrowNFT()), address(escrowNFT));
         // check can update
         Rolls newRolls = new Rolls(owner, takerNFT);
-        ShortProviderNFT newProvider =
-            new ShortProviderNFT(owner, configHub, cashAsset, collateralAsset, address(takerNFT), "", "");
+        CollarProviderNFT newProvider =
+            new CollarProviderNFT(owner, configHub, cashAsset, collateralAsset, address(takerNFT), "", "");
         EscrowSupplierNFT newEscrow = new EscrowSupplierNFT(owner, configHub, collateralAsset, "", "");
         vm.startPrank(owner);
         vm.expectEmit(address(loans));
@@ -70,7 +70,7 @@ contract LoansAdminTest is LoansTestBase {
 
         // check can unset (set to zero address)
         Rolls unsetRolls = Rolls(address(0));
-        ShortProviderNFT unsetProvider = ShortProviderNFT(address(0));
+        CollarProviderNFT unsetProvider = CollarProviderNFT(address(0));
         EscrowSupplierNFT unsetEscrow = EscrowSupplierNFT(address(0));
         vm.expectEmit(address(loans));
         emit ILoansNFT.ContractsUpdated(unsetRolls, unsetProvider, unsetEscrow);
@@ -168,7 +168,7 @@ contract LoansAdminTest is LoansTestBase {
         // Test revert when called by non-owner (tested elsewhere as well)
         vm.startPrank(user1);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user1));
-        loans.setContracts(Rolls(address(0)), ShortProviderNFT(address(0)), EscrowSupplierNFT(address(0)));
+        loans.setContracts(Rolls(address(0)), CollarProviderNFT(address(0)), EscrowSupplierNFT(address(0)));
 
         vm.startPrank(owner);
         // rolls taker match
@@ -180,7 +180,7 @@ contract LoansAdminTest is LoansTestBase {
         loans.setContracts(invalidTakerRolls, providerNFT, escrowNFT);
 
         // test provider mismatch
-        ShortProviderNFT invalidProvider = new ShortProviderNFT(
+        CollarProviderNFT invalidProvider = new CollarProviderNFT(
             owner, configHub, cashAsset, collateralAsset, address(invalidTakerNFT), "", ""
         );
         vm.expectRevert("provider taker mismatch");

--- a/test/unit/Loans.admin.t.sol
+++ b/test/unit/Loans.admin.t.sol
@@ -57,8 +57,8 @@ contract LoansAdminTest is LoansTestBase {
         // check can update
         Rolls newRolls = new Rolls(owner, takerNFT);
         CollarProviderNFT newProvider =
-            new CollarProviderNFT(owner, configHub, cashAsset, collateralAsset, address(takerNFT), "", "");
-        EscrowSupplierNFT newEscrow = new EscrowSupplierNFT(owner, configHub, collateralAsset, "", "");
+            new CollarProviderNFT(owner, configHub, cashAsset, underlying, address(takerNFT), "", "");
+        EscrowSupplierNFT newEscrow = new EscrowSupplierNFT(owner, configHub, underlying, "", "");
         vm.startPrank(owner);
         vm.expectEmit(address(loans));
         emit ILoansNFT.ContractsUpdated(newRolls, newProvider, newEscrow);
@@ -173,16 +173,15 @@ contract LoansAdminTest is LoansTestBase {
         vm.startPrank(owner);
         // rolls taker match
         CollarTakerNFT invalidTakerNFT = new CollarTakerNFT(
-            owner, configHub, cashAsset, collateralAsset, mockOracle, "InvalidTakerNFT", "INVTKR"
+            owner, configHub, cashAsset, underlying, mockOracle, "InvalidTakerNFT", "INVTKR"
         );
         Rolls invalidTakerRolls = new Rolls(owner, invalidTakerNFT);
         vm.expectRevert("rolls taker mismatch");
         loans.setContracts(invalidTakerRolls, providerNFT, escrowNFT);
 
         // test provider mismatch
-        CollarProviderNFT invalidProvider = new CollarProviderNFT(
-            owner, configHub, cashAsset, collateralAsset, address(invalidTakerNFT), "", ""
-        );
+        CollarProviderNFT invalidProvider =
+            new CollarProviderNFT(owner, configHub, cashAsset, underlying, address(invalidTakerNFT), "", "");
         vm.expectRevert("provider taker mismatch");
         loans.setContracts(rolls, invalidProvider, escrowNFT);
 

--- a/test/unit/Loans.admin.t.sol
+++ b/test/unit/Loans.admin.t.sol
@@ -134,7 +134,7 @@ contract LoansAdminTest is LoansTestBase {
         loans.openEscrowLoan(0, 0, defaultSwapParams(0), 0, 0);
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
-        loans.setKeeperAllowed(true);
+        loans.setKeeperApproved(true);
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
         loans.closeLoan(loanId, defaultSwapParams(0));

--- a/test/unit/Loans.basic.effects.t.sol
+++ b/test/unit/Loans.basic.effects.t.sol
@@ -216,7 +216,7 @@ contract LoansTestBase is BaseAssetPairTestSetup {
         assertEq(takerPosition.providerId, ids.providerId);
         assertEq(takerPosition.initialPrice, twapPrice);
         assertEq(takerPosition.takerLocked, swapOut - loanAmount);
-        assertEq(takerPosition.callLockedCash, expectedProviderLocked);
+        assertEq(takerPosition.providerLocked, expectedProviderLocked);
         assertEq(takerPosition.duration, duration);
         assertEq(takerPosition.expiration, block.timestamp + duration);
         assertFalse(takerPosition.settled);
@@ -349,7 +349,7 @@ contract LoansTestBase is BaseAssetPairTestSetup {
         CollarTakerNFT.TakerPosition memory takerPosition = takerNFT.getPosition({ takerId: loanId });
         // calculate withdrawal amounts according to expected ratios
         uint withdrawal = takerPosition.takerLocked * putRatio / BIPS_100PCT
-            + takerPosition.callLockedCash * callRatio / BIPS_100PCT;
+            + takerPosition.providerLocked * callRatio / BIPS_100PCT;
         // setup router output
         uint swapOut = prepareSwapToCollateralAtTWAPPrice();
         closeAndCheckLoan(loanId, user1, loanAmount, withdrawal, swapOut);
@@ -462,13 +462,13 @@ contract LoansBasicEffectsTest is LoansTestBase {
     function test_closeLoan_priceHalfUpToCall() public {
         uint delta = (callStrikeDeviation - BIPS_100PCT) / 2;
         uint newPrice = twapPrice * (BIPS_100PCT + delta) / BIPS_100PCT;
-        // price goes to half way to call, withdrawal is 100% takerLocked + 50% of callLocked
+        // price goes to half way to call, withdrawal is 100% takerLocked + 50% of providerLocked
         checkOpenCloseWithPriceChange(newPrice, BIPS_100PCT, BIPS_100PCT / 2);
     }
 
     function test_closeLoan_priceOverCall() public {
         uint newPrice = twapPrice * (callStrikeDeviation + BIPS_100PCT) / BIPS_100PCT;
-        // price goes over call, withdrawal is 100% takerLocked + 100% callLocked
+        // price goes over call, withdrawal is 100% takerLocked + 100% providerLocked
         checkOpenCloseWithPriceChange(newPrice, BIPS_100PCT, BIPS_100PCT);
     }
 
@@ -483,7 +483,7 @@ contract LoansBasicEffectsTest is LoansTestBase {
         uint putStrikeDeviation = ltv;
         uint delta = (BIPS_100PCT - putStrikeDeviation) / 2;
         uint newPrice = twapPrice * (BIPS_100PCT - delta) / BIPS_100PCT;
-        // price goes half way to put strike, withdrawal is 50% of takerLocked and 0% of callLocked
+        // price goes half way to put strike, withdrawal is 50% of takerLocked and 0% of providerLocked
         checkOpenCloseWithPriceChange(newPrice, BIPS_100PCT / 2, 0);
     }
 

--- a/test/unit/Loans.basic.effects.t.sol
+++ b/test/unit/Loans.basic.effects.t.sol
@@ -408,17 +408,17 @@ contract LoansBasicEffectsTest is LoansTestBase {
 
     function test_allowsClosingKeeper() public {
         startHoax(user1);
-        assertFalse(loans.allowsClosingKeeper(user1));
+        assertFalse(loans.keeperApproved(user1));
 
         vm.expectEmit(address(loans));
-        emit ILoansNFT.ClosingKeeperAllowed(user1, true);
-        loans.setKeeperAllowed(true);
-        assertTrue(loans.allowsClosingKeeper(user1));
+        emit ILoansNFT.ClosingKeeperApproved(user1, true);
+        loans.setKeeperApproved(true);
+        assertTrue(loans.keeperApproved(user1));
 
         vm.expectEmit(address(loans));
-        emit ILoansNFT.ClosingKeeperAllowed(user1, false);
-        loans.setKeeperAllowed(false);
-        assertFalse(loans.allowsClosingKeeper(user1));
+        emit ILoansNFT.ClosingKeeperApproved(user1, false);
+        loans.setKeeperApproved(false);
+        assertFalse(loans.keeperApproved(user1));
     }
 
     function test_closeLoan_simple() public {
@@ -443,7 +443,7 @@ contract LoansBasicEffectsTest is LoansTestBase {
 
         // Allow the keeper to close the loan
         vm.startPrank(user1);
-        loans.setKeeperAllowed(true);
+        loans.setKeeperApproved(true);
 
         CollarTakerNFT.TakerPosition memory takerPosition = takerNFT.getPosition({ takerId: loanId });
         // withdrawal: no price change so only user locked (put locked)

--- a/test/unit/Loans.basic.effects.t.sol
+++ b/test/unit/Loans.basic.effects.t.sol
@@ -157,8 +157,9 @@ contract LoansTestBase is BaseAssetPairTestSetup {
         emit ILoansNFT.LoanOpened(ids.loanId, user1, providerOfferId, collateralAmount, expectedLoanAmount);
 
         if (openEscrowLoan) {
-            (loanId, providerId, loanAmount) =
-                loans.openEscrowLoan(collateralAmount, minLoanAmount, swapParams, providerOfferId, escrowOfferId);
+            (loanId, providerId, loanAmount) = loans.openEscrowLoan(
+                collateralAmount, minLoanAmount, swapParams, providerOfferId, escrowOfferId
+            );
 
             // sanity checks for test values
             assertGt(escrowOfferId, 0);

--- a/test/unit/Loans.basic.effects.t.sol
+++ b/test/unit/Loans.basic.effects.t.sol
@@ -215,7 +215,7 @@ contract LoansTestBase is BaseAssetPairTestSetup {
         CollarTakerNFT.TakerPosition memory takerPosition = takerNFT.getPosition(ids.loanId);
         assertEq(address(takerPosition.providerNFT), address(providerNFT));
         assertEq(takerPosition.providerId, ids.providerId);
-        assertEq(takerPosition.initialPrice, twapPrice);
+        assertEq(takerPosition.startPrice, twapPrice);
         assertEq(takerPosition.takerLocked, swapOut - loanAmount);
         assertEq(takerPosition.providerLocked, expectedProviderLocked);
         assertEq(takerPosition.duration, duration);

--- a/test/unit/Loans.basic.reverts.t.sol
+++ b/test/unit/Loans.basic.reverts.t.sol
@@ -294,7 +294,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
         loans.closeLoan(loanId, defaultSwapParams(0));
 
         vm.startPrank(user1);
-        loans.setKeeperAllowed(true);
+        loans.setKeeperApproved(true);
 
         vm.startPrank(user1);
         // transfer invalidates approval

--- a/test/unit/Loans.basic.reverts.t.sol
+++ b/test/unit/Loans.basic.reverts.t.sol
@@ -332,11 +332,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
         skip(duration);
         uint swapOut = prepareSwapToCollateralAtTWAPPrice();
         closeAndCheckLoan(
-            loanId,
-            user1,
-            loans.getLoan(loanId).loanAmount,
-            takerNFT.getPosition(loanId).takerLocked,
-            swapOut
+            loanId, user1, loans.getLoan(loanId).loanAmount, takerNFT.getPosition(loanId).takerLocked, swapOut
         );
 
         // Try to cancel the already closed loan

--- a/test/unit/Loans.basic.reverts.t.sol
+++ b/test/unit/Loans.basic.reverts.t.sol
@@ -155,7 +155,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
     function test_revert_openLoan_IdTaken() public {
         (uint loanId,, uint loanAmount) = createAndCheckLoan();
         uint offerId = providerNFT.nextOfferId() - 1;
-        uint putLocked = swapCashAmount - loanAmount;
+        uint takerLocked = swapCashAmount - loanAmount;
 
         // prep again
         prepareSwapToCashAtTWAPPrice();
@@ -163,7 +163,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
 
         vm.mockCall(
             address(takerNFT),
-            abi.encodeWithSelector(takerNFT.openPairedPosition.selector, putLocked, providerNFT, offerId),
+            abi.encodeWithSelector(takerNFT.openPairedPosition.selector, takerLocked, providerNFT, offerId),
             abi.encode(loanId, 0, 0, 0) // returns old taker ID
         );
         vm.expectRevert("loanId taken");
@@ -335,7 +335,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
             loanId,
             user1,
             loans.getLoan(loanId).loanAmount,
-            takerNFT.getPosition(loanId).putLockedCash,
+            takerNFT.getPosition(loanId).takerLocked,
             swapOut
         );
 

--- a/test/unit/Loans.basic.reverts.t.sol
+++ b/test/unit/Loans.basic.reverts.t.sol
@@ -9,18 +9,18 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 import { LoansNFT, ILoansNFT } from "../../src/LoansNFT.sol";
 import { CollarTakerNFT } from "../../src/CollarTakerNFT.sol";
-import { ShortProviderNFT } from "../../src/ShortProviderNFT.sol";
+import { CollarProviderNFT } from "../../src/CollarProviderNFT.sol";
 import { Rolls } from "../../src/Rolls.sol";
 
 import { LoansTestBase } from "./Loans.basic.effects.t.sol";
 
 contract LoansBasicRevertsTest is LoansTestBase {
-    function openLoan(uint _col, uint _minLoan, uint _minSwap, uint _shortOffer) internal {
+    function openLoan(uint _col, uint _minLoan, uint _minSwap, uint _providerOffer) internal {
         if (openEscrowLoan) {
             // uses last set escrowOfferId
-            loans.openEscrowLoan(_col, _minLoan, defaultSwapParams(_minSwap), _shortOffer, escrowOfferId);
+            loans.openEscrowLoan(_col, _minLoan, defaultSwapParams(_minSwap), _providerOffer, escrowOfferId);
         } else {
-            loans.openLoan(_col, _minLoan, defaultSwapParams(_minSwap), _shortOffer);
+            loans.openLoan(_col, _minLoan, defaultSwapParams(_minSwap), _providerOffer);
         }
     }
 
@@ -53,7 +53,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
         // unset provider
         vm.startPrank(owner);
         configHub.setCanOpen(address(takerNFT), true);
-        loans.setContracts(rolls, ShortProviderNFT(address(0)), escrowNFT);
+        loans.setContracts(rolls, CollarProviderNFT(address(0)), escrowNFT);
         vm.startPrank(user1);
         vm.expectRevert("provider contract unset");
         openLoan(0, 0, 0, 0);

--- a/test/unit/Loans.escrow.effects.t.sol
+++ b/test/unit/Loans.escrow.effects.t.sol
@@ -236,7 +236,7 @@ contract LoansEscrowEffectsTest is LoansBasicEffectsTest {
 
         // Supplier allows the keeper to foreclose
         vm.startPrank(supplier);
-        loans.setKeeperAllowed(true);
+        loans.setKeeperApproved(true);
 
         // by keeper
         checkForecloseLoan(twapPrice, 1, keeper);

--- a/test/unit/Loans.escrow.reverts.t.sol
+++ b/test/unit/Loans.escrow.reverts.t.sol
@@ -60,13 +60,13 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
         duration += 1;
 
         // provider offer has different duration
-        uint shortOffer = createProviderOffer();
+        uint providerOffer = createProviderOffer();
 
         vm.startPrank(user1);
         prepareSwapToCashAtTWAPPrice();
         collateralAsset.approve(address(loans), collateralAmount + escrowFee);
         vm.expectRevert("duration mismatch");
-        openLoan(collateralAmount, minLoanAmount, 0, shortOffer);
+        openLoan(collateralAmount, minLoanAmount, 0, providerOffer);
 
         // loanId mismatch escrow
         vm.mockCall(
@@ -75,7 +75,7 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
             abi.encode(takerNFT.nextPositionId() - 1)
         );
         vm.expectRevert("unexpected loanId");
-        openLoan(collateralAmount, minLoanAmount, 0, shortOffer);
+        openLoan(collateralAmount, minLoanAmount, 0, providerOffer);
     }
 
     function test_revert_unwrapAndCancelLoan_timing() public {

--- a/test/unit/Loans.escrow.reverts.t.sol
+++ b/test/unit/Loans.escrow.reverts.t.sol
@@ -121,14 +121,14 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
 
         // keeper authorized by user but not supplier
         vm.startPrank(user1);
-        loans.setKeeperAllowed(true);
+        loans.setKeeperApproved(true);
         vm.startPrank(keeper);
         vm.expectRevert("not escrow owner or allowed keeper");
         loans.forecloseLoan(loanId, defaultSwapParams(0));
 
         // allow keeper
         vm.startPrank(supplier);
-        loans.setKeeperAllowed(true);
+        loans.setKeeperApproved(true);
 
         // foreclosable now
         skip(1);

--- a/test/unit/Loans.escrow.reverts.t.sol
+++ b/test/unit/Loans.escrow.reverts.t.sol
@@ -22,9 +22,9 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
 
         // not enough approval for fee
         vm.startPrank(user1);
-        collateralAsset.approve(address(loans), collateralAmount + escrowFee - 1);
+        underlying.approve(address(loans), underlyingAmount + escrowFee - 1);
         vm.expectRevert("insufficient allowance for escrow fee");
-        openLoan(collateralAmount, minLoanAmount, 0, 0);
+        openLoan(underlyingAmount, minLoanAmount, 0, 0);
 
         // unset escrow
         vm.startPrank(owner);
@@ -39,16 +39,16 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
         configHub.setCanOpen(address(escrowNFT), false);
         vm.startPrank(user1);
         vm.expectRevert("unsupported escrow contract");
-        openLoan(collateralAmount, 0, 0, 0);
+        openLoan(underlyingAmount, 0, 0, 0);
 
         // bad escrow offer
         vm.startPrank(owner);
         configHub.setCanOpen(address(escrowNFT), true);
         vm.startPrank(user1);
-        collateralAsset.approve(address(loans), collateralAmount + escrowFee);
+        underlying.approve(address(loans), underlyingAmount + escrowFee);
         escrowOfferId = 999; // invalid escrow offer
         vm.expectRevert("invalid offer");
-        openLoan(collateralAmount, minLoanAmount, 0, 0);
+        openLoan(underlyingAmount, minLoanAmount, 0, 0);
     }
 
     function test_revert_openEscrowLoan_escrowValidations() public {
@@ -64,9 +64,9 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
 
         vm.startPrank(user1);
         prepareSwapToCashAtTWAPPrice();
-        collateralAsset.approve(address(loans), collateralAmount + escrowFee);
+        underlying.approve(address(loans), underlyingAmount + escrowFee);
         vm.expectRevert("duration mismatch");
-        openLoan(collateralAmount, minLoanAmount, 0, providerOffer);
+        openLoan(underlyingAmount, minLoanAmount, 0, providerOffer);
 
         // loanId mismatch escrow
         vm.mockCall(
@@ -75,7 +75,7 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
             abi.encode(takerNFT.nextPositionId() - 1)
         );
         vm.expectRevert("unexpected loanId");
-        openLoan(collateralAmount, minLoanAmount, 0, providerOffer);
+        openLoan(underlyingAmount, minLoanAmount, 0, providerOffer);
     }
 
     function test_revert_unwrapAndCancelLoan_timing() public {
@@ -100,7 +100,7 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
         // at the end of grace period
         skip(gracePeriodEnd - block.timestamp);
         updatePrice();
-        prepareSwapToCollateralAtTWAPPrice();
+        prepareSwapToUnderlyingAtTWAPPrice();
         mockOracle.setCheckPrice(true);
         vm.expectRevert("cannot foreclose yet");
         loans.forecloseLoan(loanId, defaultSwapParams(0));
@@ -133,7 +133,7 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
         // foreclosable now
         skip(1);
         updatePrice();
-        prepareSwapToCollateralAtTWAPPrice();
+        prepareSwapToUnderlyingAtTWAPPrice();
 
         // Keeper can now foreclose
         vm.startPrank(keeper);
@@ -169,7 +169,7 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
         skip(duration + gracePeriod + 1);
         updatePrice();
         mockOracle.setCheckPrice(true);
-        uint swapOut = prepareSwapToCollateralAtTWAPPrice();
+        uint swapOut = prepareSwapToUnderlyingAtTWAPPrice();
 
         // foreclose with an invalid swapper
         vm.startPrank(supplier);

--- a/test/unit/Loans.rolls.effects.t.sol
+++ b/test/unit/Loans.rolls.effects.t.sol
@@ -30,7 +30,7 @@ contract LoansRollTestBase is LoansTestBase {
         returns (ExpectedRoll memory expected)
     {
         // roll transfers
-        (expected.toTaker,, expected.rollFee) = rolls.calculateTransferAmounts(rollId, newPrice);
+        (expected.toTaker,, expected.rollFee) = rolls.previewTransferAmounts(rollId, newPrice);
 
         uint takerId = rolls.getRollOffer(rollId).takerId;
         CollarTakerNFT.TakerPosition memory oldTakerPos = takerNFT.getPosition(takerId);
@@ -166,7 +166,7 @@ contract LoansRollTestBase is LoansTestBase {
         CollarTakerNFT.TakerPosition memory newTakerPos = takerNFT.getPosition(newLoanId);
         assertEq(newTakerPos.takerLocked, expected.newTakerLocked);
         assertEq(newTakerPos.providerLocked, expected.newProviderLocked);
-        assertEq(newTakerPos.initialPrice, newPrice);
+        assertEq(newTakerPos.startPrice, newPrice);
     }
 
     function checkCloseRolledLoan(uint loanId, uint loanAmount) public returns (uint) {

--- a/test/unit/Loans.rolls.effects.t.sol
+++ b/test/unit/Loans.rolls.effects.t.sol
@@ -38,7 +38,7 @@ contract LoansRollTestBase is LoansTestBase {
         // new position
         expected.newTakerLocked = oldTakerPos.takerLocked * newPrice / twapPrice;
         expected.newProviderLocked =
-            expected.newTakerLocked * (callStrikeDeviation - BIPS_100PCT) / (BIPS_100PCT - ltv);
+            expected.newTakerLocked * (callStrikePercent - BIPS_100PCT) / (BIPS_100PCT - ltv);
 
         // toTaker = userGain - rollFee, so userGain (loan increase) = toTaker + rollFee
         expected.newLoanAmount =

--- a/test/unit/Loans.rolls.effects.t.sol
+++ b/test/unit/Loans.rolls.effects.t.sol
@@ -14,7 +14,7 @@ import { LoansTestBase } from "./Loans.basic.effects.t.sol";
 contract LoansRollTestBase is LoansTestBase {
     struct ExpectedRoll {
         uint newTakerLocked;
-        uint newCallLocked;
+        uint newProviderLocked;
         int toTaker;
         int rollFee;
         uint newLoanAmount;
@@ -37,7 +37,7 @@ contract LoansRollTestBase is LoansTestBase {
 
         // new position
         expected.newTakerLocked = oldTakerPos.takerLocked * newPrice / twapPrice;
-        expected.newCallLocked =
+        expected.newProviderLocked =
             expected.newTakerLocked * (callStrikeDeviation - BIPS_100PCT) / (BIPS_100PCT - ltv);
 
         // toTaker = userGain - rollFee, so userGain (loan increase) = toTaker + rollFee
@@ -165,7 +165,7 @@ contract LoansRollTestBase is LoansTestBase {
         // new taker position
         CollarTakerNFT.TakerPosition memory newTakerPos = takerNFT.getPosition(newLoanId);
         assertEq(newTakerPos.takerLocked, expected.newTakerLocked);
-        assertEq(newTakerPos.callLockedCash, expected.newCallLocked);
+        assertEq(newTakerPos.providerLocked, expected.newProviderLocked);
         assertEq(newTakerPos.initialPrice, newPrice);
     }
 
@@ -188,7 +188,7 @@ contract LoansRollsEffectsTest is LoansRollTestBase {
 
         // no change in locked amounts
         assertEq(expected.newTakerLocked, takerPosition.takerLocked);
-        assertEq(expected.newCallLocked, takerPosition.callLockedCash);
+        assertEq(expected.newProviderLocked, takerPosition.providerLocked);
         // only fee paid
         assertEq(expected.toTaker, -rollFee);
         assertEq(expected.newLoanAmount, loans.getLoan(loanId).loanAmount);
@@ -210,7 +210,7 @@ contract LoansRollsEffectsTest is LoansRollTestBase {
         }
         // no change in locked amounts
         assertEq(expected.newTakerLocked, takerPosition.takerLocked);
-        assertEq(expected.newCallLocked, takerPosition.callLockedCash);
+        assertEq(expected.newProviderLocked, takerPosition.providerLocked);
         // only fee paid
         assertEq(expected.toTaker, -rollFee); // single fee
         // paid the rollFee 10 times
@@ -235,7 +235,7 @@ contract LoansRollsEffectsTest is LoansRollTestBase {
         (uint newLoanId, ExpectedRoll memory expected) = checkRollLoan(loanId, newPrice);
 
         assertEq(expected.newTakerLocked, 105 ether); // scaled by price
-        assertEq(expected.newCallLocked, 210 ether); // scaled by price
+        assertEq(expected.newProviderLocked, 210 ether); // scaled by price
         assertEq(expected.toTaker, 44 ether); // 45 (+5% * 90% LTV) - 1 (fee)
 
         // LTV & collateral relationship maintained (because within collar bounds)
@@ -252,7 +252,7 @@ contract LoansRollsEffectsTest is LoansRollTestBase {
         (uint newLoanId, ExpectedRoll memory expected) = checkRollLoan(loanId, newPrice);
 
         assertEq(expected.newTakerLocked, 95 ether); // scaled by price
-        assertEq(expected.newCallLocked, 190 ether); // scaled by price
+        assertEq(expected.newProviderLocked, 190 ether); // scaled by price
         assertEq(expected.toTaker, -46 ether); // -45 (-5% * 90% LTV) - 1 (fee)
 
         // LTV & collateral relationship maintained (because within collar bounds)
@@ -269,7 +269,7 @@ contract LoansRollsEffectsTest is LoansRollTestBase {
         (uint newLoanId, ExpectedRoll memory expected) = checkRollLoan(loanId, newPrice);
 
         assertEq(expected.newTakerLocked, 150 ether); // scaled by price
-        assertEq(expected.newCallLocked, 300 ether); // scaled by price
+        assertEq(expected.newProviderLocked, 300 ether); // scaled by price
         assertEq(expected.toTaker, 149 ether); // 150 (300 collar settle - 150 collar open) - 1 fee
 
         // LTV & collateral relationship NOT maintained because outside of collar bounds
@@ -286,7 +286,7 @@ contract LoansRollsEffectsTest is LoansRollTestBase {
         (uint newLoanId, ExpectedRoll memory expected) = checkRollLoan(loanId, newPrice);
 
         assertEq(expected.newTakerLocked, 50 ether); // scaled by price
-        assertEq(expected.newCallLocked, 100 ether); // scaled by price
+        assertEq(expected.newProviderLocked, 100 ether); // scaled by price
         assertEq(expected.toTaker, -51 ether); // -50 (0 collar settle - 50 collar open) - 1 fee
 
         // LTV & collateral relationship NOT maintained because outside of collar bounds

--- a/test/unit/Loans.rolls.effects.t.sol
+++ b/test/unit/Loans.rolls.effects.t.sol
@@ -223,7 +223,7 @@ contract LoansRollsEffectsTest is LoansRollTestBase {
 
     function test_rollLoan_setKeeperAllowed_preserved() public {
         (uint loanId,,) = createAndCheckLoan();
-        loans.setKeeperAllowed(true);
+        loans.setKeeperApproved(true);
         // checked to correspond to previous value in checkRollLoan
         checkRollLoan(loanId, twapPrice);
     }

--- a/test/unit/Loans.rolls.reverts.t.sol
+++ b/test/unit/Loans.rolls.reverts.t.sol
@@ -69,7 +69,7 @@ contract LoansRollsRevertsTest is LoansRollTestBase {
         uint newRollId = createRollOffer(newLoanId);
         vm.startPrank(user1);
         cashAsset.approve(address(loans), type(uint).max);
-        collateralAsset.approve(address(loans), escrowFee);
+        underlying.approve(address(loans), escrowFee);
         loans.rollLoan(newLoanId, newRollId, MIN_INT, escrowOfferId);
         // token is burned
         expectRevertERC721Nonexistent(newLoanId);
@@ -84,7 +84,7 @@ contract LoansRollsRevertsTest is LoansRollTestBase {
         uint rollId = createRollOffer(loanId);
 
         vm.startPrank(user1);
-        collateralAsset.approve(address(loans), escrowFee);
+        underlying.approve(address(loans), escrowFee);
         vm.mockCall(
             address(rolls),
             abi.encodeWithSelector(rolls.executeRoll.selector, rollId, 0),
@@ -254,7 +254,7 @@ contract LoansRollsEscrowRevertsTest is LoansRollsRevertsTest {
         vm.startPrank(user1);
         cashAsset.approve(address(loans), escrowFee - 1);
         cashAsset.approve(address(loans), type(uint).max);
-        collateralAsset.approve(address(loans), escrowFee - 1);
+        underlying.approve(address(loans), escrowFee - 1);
         vm.expectRevert("insufficient allowance for escrow fee");
         loans.rollLoan(loanId, rollId, MIN_INT, escrowOfferId);
 
@@ -280,7 +280,7 @@ contract LoansRollsEscrowRevertsTest is LoansRollsRevertsTest {
         vm.startPrank(user1);
         prepareSwapToCashAtTWAPPrice();
         cashAsset.approve(address(loans), type(uint).max);
-        collateralAsset.approve(address(loans), collateralAmount + escrowFee);
+        underlying.approve(address(loans), underlyingAmount + escrowFee);
         vm.expectRevert("duration mismatch");
         loans.rollLoan(loanId, rollId, MIN_INT, escrowOfferId);
 

--- a/test/unit/Loans.rolls.reverts.t.sol
+++ b/test/unit/Loans.rolls.reverts.t.sol
@@ -174,7 +174,7 @@ contract LoansRollsRevertsTest is LoansRollTestBase {
 
         // Allow the keeper to close the loan (but not roll)
         vm.startPrank(user1);
-        loans.setKeeperAllowed(true);
+        loans.setKeeperApproved(true);
 
         // Attempt to roll the loan as the keeper
         vm.startPrank(keeper);

--- a/test/unit/Loans.rolls.reverts.t.sol
+++ b/test/unit/Loans.rolls.reverts.t.sol
@@ -102,7 +102,7 @@ contract LoansRollsRevertsTest is LoansRollTestBase {
         cashAsset.approve(address(loans), type(uint).max);
 
         // Calculate expected loan change
-        (int loanChangePreview,,) = rolls.calculateTransferAmounts(rollId, twapPrice);
+        (int loanChangePreview,,) = rolls.previewTransferAmounts(rollId, twapPrice);
 
         // this reverts in Rolls
         vm.expectRevert("taker transfer slippage");
@@ -150,7 +150,7 @@ contract LoansRollsRevertsTest is LoansRollTestBase {
         updatePrice(lowPrice);
 
         // Calculate expected loan change
-        (int loanChangePreview,,) = rolls.calculateTransferAmounts(rollId, lowPrice);
+        (int loanChangePreview,,) = rolls.previewTransferAmounts(rollId, lowPrice);
         require(loanChangePreview < 0, "loanChangePreview should be negative for this test");
 
         cashAsset.approve(address(loans), uint(-loanChangePreview) - 1);
@@ -211,7 +211,7 @@ contract LoansRollsRevertsTest is LoansRollTestBase {
         int largeRepayment = -int(loanAmount + 1);
         vm.mockCall(
             address(rolls),
-            abi.encodeWithSelector(rolls.calculateTransferAmounts.selector, rollId, twapPrice),
+            abi.encodeWithSelector(rolls.previewTransferAmounts.selector, rollId, twapPrice),
             abi.encode(largeRepayment, 0, 0)
         );
         vm.mockCall(

--- a/test/unit/Rolls.t.sol
+++ b/test/unit/Rolls.t.sol
@@ -14,7 +14,7 @@ import { Rolls, IRolls } from "../../src/Rolls.sol";
 
 contract RollsTest is BaseAssetPairTestSetup {
     uint takerLocked = swapCashAmount * (BIPS_100PCT - ltv) / BIPS_100PCT; // 100
-    uint providerLocked = swapCashAmount * (callStrikeDeviation - BIPS_100PCT) / BIPS_100PCT; // 100
+    uint providerLocked = swapCashAmount * (callStrikePercent - BIPS_100PCT) / BIPS_100PCT; // 100
 
     // roll offer params
     int rollFeeAmount = 1 ether;
@@ -27,10 +27,10 @@ contract RollsTest is BaseAssetPairTestSetup {
     function createProviderOffers() internal returns (uint offerId, uint offerId2) {
         startHoax(provider);
         cashAsset.approve(address(providerNFT), largeAmount);
-        offerId = providerNFT.createOffer(callStrikeDeviation, largeAmount, ltv, duration);
+        offerId = providerNFT.createOffer(callStrikePercent, largeAmount, ltv, duration);
         // another provider NFT
         cashAsset.approve(address(providerNFT2), largeAmount);
-        offerId2 = providerNFT2.createOffer(callStrikeDeviation, largeAmount, ltv, duration);
+        offerId2 = providerNFT2.createOffer(callStrikePercent, largeAmount, ltv, duration);
     }
 
     function createTakerPositions() internal returns (uint takerId, uint providerId) {
@@ -107,11 +107,11 @@ contract RollsTest is BaseAssetPairTestSetup {
         // _newLockedAmounts
         expected.newTakerLocked = takerLocked * newPrice / twapPrice;
         expected.newProviderLocked =
-            expected.newTakerLocked * (callStrikeDeviation - BIPS_100PCT) / (BIPS_100PCT - ltv);
+            expected.newTakerLocked * (callStrikePercent - BIPS_100PCT) / (BIPS_100PCT - ltv);
         // check against taker NFT calc
         assertEq(
             expected.newProviderLocked,
-            takerNFT.calculateProviderLocked(expected.newTakerLocked, ltv, callStrikeDeviation)
+            takerNFT.calculateProviderLocked(expected.newTakerLocked, ltv, callStrikePercent)
         );
         // protocol fee
         (expected.toProtocol,) = providerNFT.protocolFee(expected.newProviderLocked, duration);
@@ -233,8 +233,8 @@ contract RollsTest is BaseAssetPairTestSetup {
         ShortProviderNFT.ProviderPosition memory newProviderPos = providerNFT.getPosition(newProviderId);
         assertEq(newProviderPos.expiration, block.timestamp + duration);
         assertEq(newProviderPos.principal, expected.newProviderLocked);
-        assertEq(newProviderPos.putStrikeDeviation, ltv);
-        assertEq(newProviderPos.callStrikeDeviation, callStrikeDeviation);
+        assertEq(newProviderPos.putStrikePercent, ltv);
+        assertEq(newProviderPos.callStrikePercent, callStrikePercent);
         assertFalse(newProviderPos.settled);
         assertEq(newProviderPos.withdrawable, 0);
     }

--- a/test/unit/Rolls.t.sol
+++ b/test/unit/Rolls.t.sol
@@ -8,7 +8,7 @@ import { IERC20Errors } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
-import { BaseAssetPairTestSetup, CollarTakerNFT, ShortProviderNFT } from "./BaseAssetPairTestSetup.sol";
+import { BaseAssetPairTestSetup, CollarTakerNFT, CollarProviderNFT } from "./BaseAssetPairTestSetup.sol";
 
 import { Rolls, IRolls } from "../../src/Rolls.sol";
 
@@ -230,7 +230,7 @@ contract RollsTest is BaseAssetPairTestSetup {
         assertEq(newTakerPos.withdrawable, 0);
 
         // Check new provider position details
-        ShortProviderNFT.ProviderPosition memory newProviderPos = providerNFT.getPosition(newProviderId);
+        CollarProviderNFT.ProviderPosition memory newProviderPos = providerNFT.getPosition(newProviderId);
         assertEq(newProviderPos.expiration, block.timestamp + duration);
         assertEq(newProviderPos.principal, expected.newProviderLocked);
         assertEq(newProviderPos.putStrikePercent, ltv);

--- a/test/utils/CollarOwnedERC20.sol
+++ b/test/utils/CollarOwnedERC20.sol
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
 pragma solidity 0.8.22;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/test/utils/MockOracleUniV3TWAP.sol
+++ b/test/utils/MockOracleUniV3TWAP.sol
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
 pragma solidity 0.8.22;
 
 import { OracleUniV3TWAP } from "../../src/OracleUniV3TWAP.sol";

--- a/test/utils/MockSwapRouter.sol
+++ b/test/utils/MockSwapRouter.sol
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
 pragma solidity 0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/utils/SwapperArbitraryCall.sol
+++ b/test/utils/SwapperArbitraryCall.sol
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
 pragma solidity 0.8.22;
 
 import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/test/utils/TestERC20.sol
+++ b/test/utils/TestERC20.sol
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
 pragma solidity 0.8.22;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/test/utils/UniswapNewPoolHelper.sol
+++ b/test/utils/UniswapNewPoolHelper.sol
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: MIT
-
-/*
- * Copyright (c) 2023 Collar Networks, Inc. <hello@collarprotocolentAsset.xyz>
- * All rights reserved. No warranty, explicit or implicit, provided.
- */
-
 pragma solidity 0.8.22;
 
 import { IUniswapV3Pool } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";


### PR DESCRIPTION
This isolates renamings into a single PR without logic changes:
- collateralAsset -> underlying
- putLocked -> takerLocked
- callLocked -> providerLocked
- deviation -> percent
- short-provider -> collar-provider
- emergency-admin -> managed
- rollFee stutter
- loan keeper methods