### PR TITLE
Reduce fork tests price movement flakiness

### DIFF
--- a/script/arbitrum-mainnet/deployer.sol
+++ b/script/arbitrum-mainnet/deployer.sol
@@ -9,7 +9,7 @@ import { DeploymentHelper } from "../deployment-helper.sol";
 
 library ArbitrumMainnetDeployer {
     uint constant chainId = 42_161; // id for arbitrum mainnet
-    address constant USDC = 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8;
+    address constant USDC = 0xaf88d065e77c8cC2239327C5EDb3A432268e5831;
     address constant USDT = 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9;
     address constant WETH = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
 

--- a/script/arbitrum-mainnet/deployer.sol
+++ b/script/arbitrum-mainnet/deployer.sol
@@ -134,11 +134,11 @@ library ArbitrumMainnetDeployer {
 
         assetPairContracts[1] = DeploymentHelper.deployContractPair(configHub, USDTWETHPairConfig, owner);
 
-        DeploymentHelper.PairConfig memory USDCWBTCPairConfig = DeploymentHelper.PairConfig({
-            name: "USDC/WBTC",
+        DeploymentHelper.PairConfig memory USDTWBTCPairConfig = DeploymentHelper.PairConfig({
+            name: "USDT/WBTC",
             durations: allDurations,
             ltvs: allLTVs,
-            cashAsset: IERC20(USDC),
+            cashAsset: IERC20(USDT),
             underlying: IERC20(WBTC),
             oracleFeeTier: oracleFeeTier,
             swapFeeTier: swapFeeTier,
@@ -148,20 +148,6 @@ library ArbitrumMainnetDeployer {
             existingEscrowNFT: address(0)
         });
 
-        assetPairContracts[2] = DeploymentHelper.deployContractPair(configHub, USDCWBTCPairConfig, owner);
-
-        // DeploymentHelper.PairConfig memory USDCMATICPairConfig = DeploymentHelper.PairConfig({
-        //     name: "USDC/MATIC",
-        //     durations: singleDuration,
-        //     ltvs: singleLTV,
-        //     cashAsset: IERC20(USDC),
-        //     underlying: IERC20(MATIC),
-        //     oracleFeeTier: oracleFeeTier,
-        //     swapFeeTier: swapFeeTier,
-        //     twapWindow: twapWindow,
-        //     swapRouter: swapRouterAddress
-        // });
-
-        // assetPairContracts[3] = deployContractPair(configHub, USDCMATICPairConfig, owner);
+        assetPairContracts[2] = DeploymentHelper.deployContractPair(configHub, USDTWBTCPairConfig, owner);
     }
 }

--- a/test/integration/arbitrum-mainnet/BaseForkTest.sol
+++ b/test/integration/arbitrum-mainnet/BaseForkTest.sol
@@ -105,7 +105,6 @@ abstract contract LoansTestBase is Test, DeploymentLoader {
 
 abstract contract BaseLoansForkTest is LoansTestBase {
     // constants for all pairs
-    uint constant slippage = 100; // 1%
     uint constant BIPS_BASE = 10_000;
 
     //escrow related constants
@@ -142,8 +141,8 @@ abstract contract BaseLoansForkTest is LoansTestBase {
     // whale address
     address whale;
 
-    // durations to use
-    uint callstrikeToUse = 12_000;
+    uint slippage;
+    uint callstrikeToUse;
     uint duration;
     uint durationPriceMovement;
 
@@ -522,7 +521,7 @@ abstract contract BaseLoansForkTest is LoansTestBase {
         (uint loanId,, uint loanAmount) = openLoan(pair, user, underlyingAmount, minLoanAmount, offerId);
 
         ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
-        skip(durationPriceMovement);
+        skip(durationPriceMovement / 2);
 
         // Move price above call strike using lib
         PriceMovementHelper.moveToTargetPrice(
@@ -536,6 +535,9 @@ abstract contract BaseLoansForkTest is LoansTestBase {
             swapStepCashAmount,
             swapPoolFeeTier
         );
+
+        // moving price takes time, but we need settlement price to be moved
+        skip(durationPriceMovement / 2);
 
         (uint expectedTakerWithdrawal,) =
             pair.takerNFT.previewSettlement(position, pair.oracle.currentPrice());
@@ -569,7 +571,7 @@ abstract contract BaseLoansForkTest is LoansTestBase {
 
         ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
 
-        skip(durationPriceMovement);
+        skip(durationPriceMovement / 2);
 
         // Move price below put strike
         PriceMovementHelper.moveToTargetPrice(
@@ -583,6 +585,9 @@ abstract contract BaseLoansForkTest is LoansTestBase {
             swapStepCashAmount,
             swapPoolFeeTier
         );
+
+        // moving price takes time, but we need settlement price to be moved
+        skip(durationPriceMovement / 2);
 
         uint userUnderlyingBefore = pair.underlying.balanceOf(user);
         // Close loan
@@ -606,7 +611,7 @@ abstract contract BaseLoansForkTest is LoansTestBase {
 
         ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
 
-        skip(durationPriceMovement);
+        skip(durationPriceMovement / 2);
 
         // Move price half way to call strike using lib
         uint halfDeviation = (BIPS_BASE + position.callStrikePercent) / 2;
@@ -621,6 +626,9 @@ abstract contract BaseLoansForkTest is LoansTestBase {
             swapStepCashAmount,
             swapPoolFeeTier
         );
+
+        // moving price takes time, but we need settlement price to be moved
+        skip(durationPriceMovement / 2);
 
         // Calculate expected settlement amounts
         uint currentPrice = pair.oracle.currentPrice();

--- a/test/integration/arbitrum-mainnet/BaseForkTest.sol
+++ b/test/integration/arbitrum-mainnet/BaseForkTest.sol
@@ -115,7 +115,6 @@ abstract contract BaseLoansForkTest is LoansTestBase {
 
     // Protocol fee params
     uint constant feeAPR = 100; // 1% APR
-    uint constant callstrikeToUse = 12_000;
 
     // values to be set by pair
     address cashAsset;
@@ -144,6 +143,7 @@ abstract contract BaseLoansForkTest is LoansTestBase {
     address whale;
 
     // durations to use
+    uint callstrikeToUse = 12_000;
     uint duration;
     uint durationPriceMovement;
 

--- a/test/integration/arbitrum-mainnet/BaseForkTest.sol
+++ b/test/integration/arbitrum-mainnet/BaseForkTest.sol
@@ -518,11 +518,11 @@ abstract contract BaseLoansForkTest is LoansTestBase {
 
     function testSettlementPriceAboveCallStrike() public {
         // Create provider offer & open loan
-        uint offerId = createProviderOffer(pair, callstrikeToUse, offerAmount, pair.durations[1]);
+        uint offerId = createProviderOffer(pair, callstrikeToUse, offerAmount, durationPriceMovement);
         (uint loanId,, uint loanAmount) = openLoan(pair, user, underlyingAmount, minLoanAmount, offerId);
 
         ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
-        skip(pair.durations[1] / 2);
+        skip(durationPriceMovement);
 
         // Move price above call strike using lib
         PriceMovementHelper.moveToTargetPrice(
@@ -536,8 +536,6 @@ abstract contract BaseLoansForkTest is LoansTestBase {
             swapStepCashAmount,
             swapPoolFeeTier
         );
-
-        skip(pair.durations[1] / 2);
 
         (uint expectedTakerWithdrawal,) =
             pair.takerNFT.previewSettlement(position, pair.oracle.currentPrice());
@@ -566,12 +564,12 @@ abstract contract BaseLoansForkTest is LoansTestBase {
 
     function testSettlementPriceBelowPutStrike() public {
         // Create provider offer & open loan
-        uint offerId = createProviderOffer(pair, callstrikeToUse, offerAmount, pair.durations[1]);
+        uint offerId = createProviderOffer(pair, callstrikeToUse, offerAmount, durationPriceMovement);
         (uint loanId,, uint loanAmount) = openLoan(pair, user, underlyingAmount, minLoanAmount, offerId);
 
         ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
 
-        skip(pair.durations[1] / 2);
+        skip(durationPriceMovement);
 
         // Move price below put strike
         PriceMovementHelper.moveToTargetPrice(
@@ -586,7 +584,6 @@ abstract contract BaseLoansForkTest is LoansTestBase {
             swapPoolFeeTier
         );
 
-        skip(pair.durations[1] / 2);
         uint userUnderlyingBefore = pair.underlying.balanceOf(user);
         // Close loan
         closeAndCheckLoan(loanId, loanAmount, loanAmount, 0);
@@ -609,7 +606,7 @@ abstract contract BaseLoansForkTest is LoansTestBase {
 
         ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
 
-        skip(durationPriceMovement / 2);
+        skip(durationPriceMovement);
 
         // Move price half way to call strike using lib
         uint halfDeviation = (BIPS_BASE + position.callStrikePercent) / 2;
@@ -624,8 +621,6 @@ abstract contract BaseLoansForkTest is LoansTestBase {
             swapStepCashAmount,
             swapPoolFeeTier
         );
-
-        skip(durationPriceMovement / 2);
 
         // Calculate expected settlement amounts
         uint currentPrice = pair.oracle.currentPrice();

--- a/test/integration/arbitrum-mainnet/Loans.fork.t.sol
+++ b/test/integration/arbitrum-mainnet/Loans.fork.t.sol
@@ -21,10 +21,8 @@ contract USDCWETHForkTest is BaseLoansForkTest {
         bigUnderlyingAmount = 1000 ether;
         swapPoolFeeTier = 500;
 
-        // Initial swap amounts (from proven fork tests)
-        amountForCallstrike = 1_000_000e6; // Amount in USDC to move past call strike
-        amountForPutstrike = 250 ether; // Amount in WETH to move past put strike
-        amountForPartialMove = 600_000e6; // Amount in USDC to move partially up
+        // price movement swap amounts
+        swapStepCashAmount = 1_000_000e6;
 
         pair = getPairByAssets(address(cashAsset), address(underlying));
         require(address(pair.loansContract) != address(0), "Loans contract not deployed");
@@ -60,10 +58,8 @@ contract USDTWETHForkTest is BaseLoansForkTest {
         bigUnderlyingAmount = 1000 ether;
         swapPoolFeeTier = 500;
 
-        // Initial swap amounts (from proven fork tests)
-        amountForCallstrike = 2_000_000e6; // Amount in USDC to move past call strike
-        amountForPutstrike = 250 ether; // Amount in WETH to move past put strike
-        amountForPartialMove = 600_000e6; // Amount in USDC to move partially up
+        // price movement swap amounts
+        swapStepCashAmount = 1_000_000e6;
 
         pair = getPairByAssets(address(cashAsset), address(underlying));
         require(address(pair.loansContract) != address(0), "Loans contract not deployed");
@@ -99,10 +95,8 @@ contract USDCWBTCForkTest is BaseLoansForkTest {
         bigUnderlyingAmount = 100e8;
         swapPoolFeeTier = 500;
 
-        // Initial swap amounts (from proven fork tests)
-        amountForCallstrike = 70_000e6; // Amount in USDC to move past call strike
-        amountForPutstrike = 1e8; // Amount in WBTC to move past put strike
-        amountForPartialMove = 15_000e6; // Amount in USDC to move partially up
+        // price movement swap amounts
+        swapStepCashAmount = 1_000_000e6;
 
         // change callstrike cause price impact is harder to manage on this pool
 

--- a/test/integration/arbitrum-mainnet/Loans.fork.t.sol
+++ b/test/integration/arbitrum-mainnet/Loans.fork.t.sol
@@ -10,7 +10,7 @@ contract USDCWETHForkTest is BaseLoansForkTest {
         super.setUp();
 
         // set up all the variables for this pair
-        cashAsset = 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8; // USDC
+        cashAsset = 0xaf88d065e77c8cC2239327C5EDb3A432268e5831; // USDC
         underlying = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1; // WETH
         offerAmount = 100_000e6;
         underlyingAmount = 1 ether;
@@ -22,7 +22,7 @@ contract USDCWETHForkTest is BaseLoansForkTest {
         swapPoolFeeTier = 500;
 
         // price movement swap amounts
-        swapStepCashAmount = 1_000_000e6;
+        swapStepCashAmount = 250_000e6;
 
         pair = getPairByAssets(address(cashAsset), address(underlying));
         require(address(pair.loansContract) != address(0), "Loans contract not deployed");

--- a/test/integration/arbitrum-mainnet/Loans.fork.t.sol
+++ b/test/integration/arbitrum-mainnet/Loans.fork.t.sol
@@ -83,6 +83,8 @@ contract USDTWBTCForkTest is BaseLoansForkTest {
     function setUp() public override {
         super.setUp();
 
+        callstrikeToUse = 11_000; // not enough liquidity at 120%
+
         // set up all the variables for this pair
         cashAsset = 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9; // USDT
         underlying = 0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f; // WBTC
@@ -96,7 +98,7 @@ contract USDTWBTCForkTest is BaseLoansForkTest {
         swapPoolFeeTier = 500;
 
         // price movement swap amounts
-        swapStepCashAmount = 1_000_000e6;
+        swapStepCashAmount = 500_000e6;
 
         // change callstrike cause price impact is harder to manage on this pool
 

--- a/test/integration/arbitrum-mainnet/Loans.fork.t.sol
+++ b/test/integration/arbitrum-mainnet/Loans.fork.t.sol
@@ -9,6 +9,26 @@ contract USDCWETHForkTest is BaseLoansForkTest {
     function setUp() public override {
         super.setUp();
 
+        _setParams();
+
+        pair = getPairByAssets(address(cashAsset), address(underlying));
+        require(address(pair.loansContract) != address(0), "Loans contract not deployed");
+
+        // Fund whale for price manipulation
+        deal(address(pair.cashAsset), whale, 100 * bigCashAmount);
+        deal(address(pair.underlying), whale, 100 * bigUnderlyingAmount);
+
+        // Setup protocol fee
+        vm.startPrank(owner);
+        configHub.setProtocolFeeParams(feeAPR, feeRecipient);
+        vm.stopPrank();
+        fundWallets();
+
+        duration = pair.durations[0];
+        durationPriceMovement = pair.durations[1];
+    }
+
+    function _setParams() internal virtual {
         // set up all the variables for this pair
         cashAsset = 0xaf88d065e77c8cC2239327C5EDb3A432268e5831; // USDC
         underlying = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1; // WETH
@@ -21,101 +41,31 @@ contract USDCWETHForkTest is BaseLoansForkTest {
         bigUnderlyingAmount = 1000 ether;
         swapPoolFeeTier = 500;
 
-        // price movement swap amounts
-        swapStepCashAmount = 250_000e6;
-
-        pair = getPairByAssets(address(cashAsset), address(underlying));
-        require(address(pair.loansContract) != address(0), "Loans contract not deployed");
-
-        // Fund whale for price manipulation
-        deal(address(pair.cashAsset), whale, 100 * bigCashAmount);
-        deal(address(pair.underlying), whale, 100 * bigUnderlyingAmount);
-
-        // Setup protocol fee
-        vm.startPrank(owner);
-        configHub.setProtocolFeeParams(feeAPR, feeRecipient);
-        vm.stopPrank();
-        fundWallets();
-
-        duration = pair.durations[0];
-        durationPriceMovement = pair.durations[1];
-    }
-}
-
-contract USDTWETHForkTest is BaseLoansForkTest {
-    function setUp() public override {
-        super.setUp();
-
-        // set up all the variables for this pair
-        cashAsset = 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9; // USDT
-        underlying = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1; // WETH
-        offerAmount = 100_000e6;
-        underlyingAmount = 1 ether;
-        minLoanAmount = 0.3e6; // arbitrary low value
-        rollFee = 100e6;
-        rollDeltaFactor = 10_000;
-        bigCashAmount = 1_000_000e6;
-        bigUnderlyingAmount = 1000 ether;
-        swapPoolFeeTier = 500;
+        slippage = 100; // 1%
+        callstrikeToUse = 11_000;
 
         // price movement swap amounts
         swapStepCashAmount = 1_000_000e6;
-
-        pair = getPairByAssets(address(cashAsset), address(underlying));
-        require(address(pair.loansContract) != address(0), "Loans contract not deployed");
-
-        // Fund whale for price manipulation
-        deal(address(pair.cashAsset), whale, 100 * bigCashAmount);
-        deal(address(pair.underlying), whale, 100 * bigUnderlyingAmount);
-
-        // Setup protocol fee
-        vm.startPrank(owner);
-        configHub.setProtocolFeeParams(feeAPR, feeRecipient);
-        vm.stopPrank();
-        fundWallets();
-
-        duration = pair.durations[0];
-        durationPriceMovement = pair.durations[1];
     }
 }
 
-contract USDTWBTCForkTest is BaseLoansForkTest {
-    function setUp() public override {
-        super.setUp();
+contract USDTWETHForkTest is USDCWETHForkTest {
+    function _setParams() internal virtual override {
+        super._setParams();
+        cashAsset = 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9; // USDT
+        underlying = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1; // WETH
+    }
+}
 
-        callstrikeToUse = 11_000; // not enough liquidity at 120%
-
-        // set up all the variables for this pair
+contract USDTWBTCForkTest is USDCWETHForkTest {
+    function _setParams() internal virtual override {
+        super._setParams();
         cashAsset = 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9; // USDT
         underlying = 0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f; // WBTC
-        offerAmount = 100_000e6;
         underlyingAmount = 0.1e8;
-        minLoanAmount = 0.3e6; // arbitrary low value
-        rollFee = 100e6;
-        rollDeltaFactor = 10_000;
-        bigCashAmount = 1_000_000e6;
         bigUnderlyingAmount = 100e8;
-        swapPoolFeeTier = 500;
 
-        // price movement swap amounts
+        callstrikeToUse = 10_500;
         swapStepCashAmount = 500_000e6;
-
-        // change callstrike cause price impact is harder to manage on this pool
-
-        pair = getPairByAssets(address(cashAsset), address(underlying));
-        require(address(pair.loansContract) != address(0), "Loans contract not deployed");
-
-        // Fund whale for price manipulation
-        deal(address(pair.cashAsset), whale, 100 * bigCashAmount);
-        deal(address(pair.underlying), whale, 100 * bigUnderlyingAmount);
-
-        // Setup protocol fee
-        vm.startPrank(owner);
-        configHub.setProtocolFeeParams(feeAPR, feeRecipient);
-        vm.stopPrank();
-        fundWallets();
-
-        duration = pair.durations[0];
-        durationPriceMovement = pair.durations[1];
     }
 }

--- a/test/integration/arbitrum-mainnet/Loans.fork.t.sol
+++ b/test/integration/arbitrum-mainnet/Loans.fork.t.sol
@@ -79,12 +79,12 @@ contract USDTWETHForkTest is BaseLoansForkTest {
     }
 }
 
-contract USDCWBTCForkTest is BaseLoansForkTest {
+contract USDTWBTCForkTest is BaseLoansForkTest {
     function setUp() public override {
         super.setUp();
 
         // set up all the variables for this pair
-        cashAsset = 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8; // USDT
+        cashAsset = 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9; // USDT
         underlying = 0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f; // WBTC
         offerAmount = 100_000e6;
         underlyingAmount = 0.1e8;

--- a/test/integration/utils/PriceMovement.sol
+++ b/test/integration/utils/PriceMovement.sol
@@ -11,7 +11,7 @@ library PriceMovementHelper {
     using SafeERC20 for IERC20;
 
     // Price movement configuration
-    uint constant STEPS = 10;
+    uint constant STEPS = 20;
     // 15 minutes, to allow for longer TWAP windows
     uint constant STEP_DELAY = 900 seconds;
     uint constant BIPS_BASE = 10_000;

--- a/test/integration/utils/PriceMovement.sol
+++ b/test/integration/utils/PriceMovement.sol
@@ -28,12 +28,12 @@ library PriceMovementHelper {
     ) internal {
         uint currentPrice = oracle.currentPrice();
         bool increasePrice = targetPrice > currentPrice;
+        uint underlyingStepAmount = oracle.convertToBaseAmount(cashPerStep, currentPrice);
 
         for (uint i = 0; i < STEPS; i++) {
             if (increasePrice) {
                 swapCash(vm, swapRouter, whale, cashAsset, underlying, cashPerStep, poolFee);
             } else {
-                uint underlyingStepAmount = oracle.convertToBaseAmount(cashPerStep, currentPrice);
                 swapUnderlying(vm, swapRouter, whale, cashAsset, underlying, underlyingStepAmount, poolFee);
             }
             vm.warp(block.timestamp + STEP_DELAY);

--- a/test/integration/utils/PriceMovement.sol
+++ b/test/integration/utils/PriceMovement.sol
@@ -12,7 +12,8 @@ library PriceMovementHelper {
 
     // Price movement configuration
     uint constant STEPS = 10;
-    uint constant STEP_DELAY = 300 seconds;
+    // 15 minutes, to allow for longer TWAP windows
+    uint constant STEP_DELAY = 900 seconds;
     uint constant BIPS_BASE = 10_000;
 
     function moveToTargetPrice(


### PR DESCRIPTION
Fixes:
- simplify price movements lib and usage
- increase step time delay to do fewer swaps and prevent swap and twap mismatch issue
- use only cash amount in both directions (and use current price to convert)
- fix wrong BTC pair
- set params for the less liquid BTC pair