### PR TITLE
Fix escrow DoS issue

### DIFF
--- a/src/LoansNFT.sol
+++ b/src/LoansNFT.sol
@@ -814,11 +814,10 @@ contract LoansNFT is ILoansNFT, BaseNFT {
 
             if (!escrowReleased) {
                 // if not released, release the user funds to the supplier since the user will not repay
-                // the loan. There's no late fees - loan hsa not expired, but also no repayment - there was
+                // the loan. There's no late fees - loan has not expired, but also no repayment - there was
                 // no swap. There may be an interest fee refund for the borrower.
-                // @dev For an open + immediate cancel all fees are refunded, however, this is unlikely to
-                // be used to grief supplier offers, since it would both costs swap fees and lock
-                // funds in the taker position.
+                // @dev In immediate cancellation: NOT all escrow fee is refunded. A minimal fee is ensured
+                // to prevent DoS of escrow offers by cycling them into withdrawals.
                 uint feeRefund = escrowNFT.endEscrow(escrowId, 0);
                 // @dev no balance checks because contract holds no funds, mismatch will cause reverts
 

--- a/test/integration/arbitrum-mainnet/BaseForkTest.sol
+++ b/test/integration/arbitrum-mainnet/BaseForkTest.sol
@@ -521,7 +521,7 @@ abstract contract BaseLoansForkTest is LoansTestBase {
         (uint loanId,, uint loanAmount) = openLoan(pair, user, underlyingAmount, minLoanAmount, offerId);
 
         ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
-        
+
         skip(durationPriceMovement / 2);
 
         // Move price above call strike using lib

--- a/test/integration/arbitrum-mainnet/Loans.fork.t.sol
+++ b/test/integration/arbitrum-mainnet/Loans.fork.t.sol
@@ -60,7 +60,7 @@ contract USDTWETHForkTest is USDCWETHForkTest {
 contract USDTWBTCForkTest is USDCWETHForkTest {
     function _setParams() internal virtual override {
         super._setParams();
-        
+
         cashAsset = 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9; // USDT
         underlying = 0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f; // WBTC
         underlyingAmount = 0.1e8;

--- a/test/integration/utils/PriceMovement.sol
+++ b/test/integration/utils/PriceMovement.sol
@@ -10,7 +10,7 @@ import { ITakerOracle } from "../../../src/interfaces/ITakerOracle.sol";
 library PriceMovementHelper {
     using SafeERC20 for IERC20;
 
-    // Price movement 
+    // Price movement
     uint constant STEPS = 20;
     // 15 minutes, to allow for longer TWAP windows
     uint constant STEP_DELAY = 900 seconds;

--- a/test/unit/Loans.basic.effects.t.sol
+++ b/test/unit/Loans.basic.effects.t.sol
@@ -422,6 +422,7 @@ contract LoansBasicEffectsTest is LoansTestBase {
 
     function test_constructor() public {
         loans = new LoansNFT(owner, takerNFT, "", "");
+        assertEq(loans.MAX_SWAP_TWAP_DEVIATION_BIPS(), 1000);
         assertEq(address(loans.configHub()), address(configHub));
         assertEq(address(loans.takerNFT()), address(takerNFT));
         assertEq(address(loans.cashAsset()), address(cashAsset));

--- a/test/unit/Loans.basic.reverts.t.sol
+++ b/test/unit/Loans.basic.reverts.t.sol
@@ -93,6 +93,11 @@ contract LoansBasicRevertsTest is LoansTestBase {
         mockSwapperRouter.setupSwap(swapCashAmount, swapCashAmount);
         vm.expectRevert("SwapperUniV3: slippage exceeded");
         openLoan(underlyingAmount, minLoanAmount, swapCashAmount + 1, offerId);
+
+        // deviation vs.TWAP
+        prepareSwap(cashAsset, swapCashAmount / 2);
+        vm.expectRevert("swap and twap price too different");
+        openLoan(underlyingAmount, minLoanAmount, 0, offerId);
     }
 
     function test_revert_openLoan_swapper_not_allowed() public {

--- a/test/unit/Loans.rolls.effects.t.sol
+++ b/test/unit/Loans.rolls.effects.t.sol
@@ -311,8 +311,9 @@ contract LoansRollsEscrowEffectsTest is LoansRollsEffectsTest {
         (uint loanId,,) = createAndCheckLoan();
         uint prevFee = escrowFee;
         (, ExpectedRoll memory expected) = checkRollLoan(loanId, twapPrice);
-        // full refund
-        assertEq(expected.escrowFeeRefund, prevFee);
+        // max refund
+        uint maxRefund = escrowNFT.MAX_FEE_REFUND_BIPS() * prevFee / BIPS_100PCT;
+        assertEq(expected.escrowFeeRefund, maxRefund);
 
         (loanId,,) = createAndCheckLoan();
         skip(duration / 2);


### PR DESCRIPTION
Fixes a DoS issue for escrow:

### Scenario 1 (no protocol fee):
- attacker sees escrow offers they want to block (e.g., a competing offers with lower interest rate)
- attacker creates own provider offer with 0 `minLocked`
- attacker takes loan, this results in escrow being taken, and escrow fee held
- attacker immediately unwraps loan - this returns the escrow,  making it withdrawable, and refunds the full upfront interest fee (since no time elapsed)
- attacker cancels the collar position (since holds both sides)

### Scenario 2 (with protocol fee):
- same as previous but, during open they sandwich their own swap to manipulate price down, such that swap results in nearly 0 cash out. This results in escrow being taken, and escrow fee held, but almost no protocol fees paid.

### Scenario 3
- Similar to the above two, but using rolls instead of cancellations.

The impact is that attacker can cycle any targeted escrow offers from offers to withdrawals, either DoSing all escrow loans, or more likely DoSing competitor escrow suppliers (increasing escrow costs for users).

### Med severity: 
- Likelihood is medium for scenario 1 (no sandwich, pays swap fees, but requires protocol fee to be 0, which reduces likelihood).  
- Likelihood is low for scenario 2 (complex + pays swap fees for roundtrip price manipulation + needs flashloan and possibly flashloan fee), unless a more fleixble swapper is used (in which case likelihood is as for scenario 1).
- Impact is medium (ongoing DOS of escrow loans, at a cost to attacker). 

### Mitigations:
- Do not refund escrow interest fee fully. Instead let escrow owner keep X% of it for the trouble of having to move the funds from withdrawals back into offers, and to prevent immediate free cancellations. Resolves the root cause - free escrow cancellation / switch.
- Add back the previously removed twap-swap price check in loan open. This seems prudent to prevent other possible edge-cases that use this mismatch. A precaution for other issues more than a mitigation for this one (since first mitigation is sufficient). This was removed before for lack of actual usefulness, but this examples shows how it could be useful.