### PR TITLE
Upfront late fee

### DIFF
--- a/src/EscrowSupplierNFT.sol
+++ b/src/EscrowSupplierNFT.sol
@@ -545,7 +545,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
             // cap at specified grace period
             overdue = Math.min(overdue, escrow.gracePeriod);
         }
-        // round down against borrower
+        // round down against borrower (again, because lateFeeHeld is rounded up).
         return lateFeeHeld * (escrow.gracePeriod - overdue) / escrow.gracePeriod;
     }
 

--- a/src/EscrowSupplierNFT.sol
+++ b/src/EscrowSupplierNFT.sol
@@ -163,7 +163,9 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
      * @notice Creates a new escrow offer
      * @param amount The offered amount
      * @param duration The offer duration in seconds
-     * @param interestAPR The annual interest rate in basis points
+     * @param interestAPR The annual interest rate in basis points. At most MAX_FEE_REFUND_BIPS
+     * of the upfront interest can be refunded on cancellation. If interestAPR is 0, this
+     * will have no effect, and allow free cancellations.
      * @param gracePeriod The maximum grace period duration in seconds
      * @param lateFeeAPR The annual late fee rate in basis points
      * @param minEscrow The minimum escrow amount. Protection from dust mints.
@@ -241,7 +243,8 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
      * @param offerId The ID of the offer to use
      * @param escrowed The amount to escrow
      * @param fees The upfront interest and late fees to hold. Checked to be sufficient.
-     *   Will be partially refunded depending on escrow release time.
+     *   Will be partially refunded depending on escrow release time. If overpaid, any overpayment
+     *   will be refunded when escrow will be released (if not seized after grace period).
      * @param loanId The associated loan ID
      * @return escrowId The ID of the created escrow
      */

--- a/src/EscrowSupplierNFT.sol
+++ b/src/EscrowSupplierNFT.sol
@@ -94,7 +94,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
             available: stored.available,
             duration: stored.duration,
             interestAPR: stored.interestAPR,
-            maxGracePeriod: stored.maxGracePeriod,
+            gracePeriod: stored.gracePeriod,
             lateFeeAPR: stored.lateFeeAPR,
             minEscrow: stored.minEscrow
         });
@@ -112,68 +112,31 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
             loans: stored.loans,
             loanId: stored.loanId,
             escrowed: stored.escrowed,
-            maxGracePeriod: offer.maxGracePeriod,
+            gracePeriod: offer.gracePeriod,
             lateFeeAPR: offer.lateFeeAPR,
             duration: offer.duration,
             expiration: stored.expiration,
-            interestHeld: stored.interestHeld,
+            feesHeld: stored.feesHeld,
             released: stored.released,
             withdrawable: stored.withdrawable
         });
     }
 
     /**
-     * @notice Returns the total owed including late fees for an escrow.
-     * Uses a MIN_GRACE_PERIOD "cliff": Overdue time is counted from expiry, but during
-     * the MIN_GRACE_PERIOD late fees are returned as 0 (even though are "accumulating" for it).
-     * @param escrowId The ID of the escrow to calculate late fees for
-     * @return totalOwed Total owed: escrowed amount + late fee
-     * @return lateFee The calculated late fee
-     */
-    function currentOwed(uint escrowId) external view returns (uint totalOwed, uint lateFee) {
-        Escrow memory escrow = getEscrow(escrowId);
-        lateFee = _lateFee(escrow);
-        return (escrow.escrowed + lateFee, lateFee);
-    }
-
-    /**
-     * @notice Calculates the grace period based on available late fee amount. This is the grace period
-     * the maxLateFee "can afford" before causing an shortfall of late fees. This view should be used to
-     * enforce a reduced gracePeriod in available case funds are insufficient for the full grace period.
-     * Grace period returned is between MIN_GRACE_PERIOD and the offer's `gracePeriod`.
-     * @param escrowId The ID of the escrow to calculate for
-     * @param maxLateFee The available fee amount
-     * @return The calculated grace period in seconds
-     */
-    function cappedGracePeriod(uint escrowId, uint maxLateFee) external view returns (uint) {
-        Escrow memory escrow = getEscrow(escrowId);
-        // initialize with max according to terms
-        uint period = escrow.maxGracePeriod;
-        // avoid div-zero
-        if (escrow.escrowed != 0 && escrow.lateFeeAPR != 0) {
-            // Calculate the grace period that can be "afforded" by maxLateFee according to fee APR.
-            //  fee = escrowed * time * APR / year / 100%, so
-            //  time = fee * year * 100% / escrowed / APR;
-            // rounding down, against the user
-            uint timeAfforded = maxLateFee * YEAR * BIPS_BASE / escrow.escrowed / escrow.lateFeeAPR;
-            // cap to timeAfforded
-            period = Math.min(timeAfforded, period);
-        }
-        // ensure MIN_GRACE_PERIOD, which means that even if no funds are available, min grace period
-        // is available.
-        return Math.max(period, MIN_GRACE_PERIOD);
-    }
-
-    /**
-     * @notice Calculates the interest fee (to be deposited upfront) for an offer and escrow amount.
+     * @notice Calculates the upfront interest fee and late fee held for an offer and escrow amount.
      * @param offerId The offer Id to use for calculations
      * @param escrowed The escrowed amount
-     * @return fee The calculated interest fee
+     * @return total The calculated total fees (interest and late fee)
+     * @return interestFee The calculated interest fee to hold
+     * @return lateFee The calculated late fee to hold
      */
-    function interestFee(uint offerId, uint escrowed) public view returns (uint) {
-        Offer memory offer = getOffer(offerId);
-        // rounds up against the user
-        return Math.ceilDiv(escrowed * offer.interestAPR * offer.duration, BIPS_BASE * YEAR);
+    function upfrontFees(uint offerId, uint escrowed)
+        public
+        view
+        returns (uint total, uint interestFee, uint lateFee)
+    {
+        (interestFee, lateFee) = _upfrontFees(offerId, escrowed);
+        total = interestFee + lateFee;
     }
 
     /**
@@ -182,15 +145,14 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
      * @param fromLoans The amount repaid from loans
      * @return withdrawal The amount to be withdrawn by the supplier
      * @return toLoans The amount to be returned to loans (includes refund)
-     * @return interestRefund The refunded interest amount
+     * @return feesRefund The refunded interest amount
      */
     function previewRelease(uint escrowId, uint fromLoans)
         external
         view
-        returns (uint withdrawal, uint toLoans, uint interestRefund)
+        returns (uint withdrawal, uint toLoans, uint feesRefund)
     {
-        // shouldRefund is true since this simulates endEscrow (with refund)
-        (withdrawal, toLoans, interestRefund) = _releaseCalculations(getEscrow(escrowId), fromLoans, true);
+        (withdrawal, toLoans, feesRefund) = _releaseCalculations(getEscrow(escrowId), fromLoans);
     }
 
     // ----- MUTATIVE ----- //
@@ -202,7 +164,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
      * @param amount The offered amount
      * @param duration The offer duration in seconds
      * @param interestAPR The annual interest rate in basis points
-     * @param maxGracePeriod The maximum grace period duration in seconds
+     * @param gracePeriod The maximum grace period duration in seconds
      * @param lateFeeAPR The annual late fee rate in basis points
      * @param minEscrow The minimum escrow amount. Protection from dust mints.
      * @return offerId The ID of the created offer
@@ -211,21 +173,21 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
         uint amount,
         uint duration,
         uint interestAPR,
-        uint maxGracePeriod,
+        uint gracePeriod,
         uint lateFeeAPR,
         uint minEscrow
     ) external whenNotPaused returns (uint offerId) {
         // sanity checks
         require(interestAPR <= MAX_INTEREST_APR_BIPS, "escrow: interest APR too high");
         require(lateFeeAPR <= MAX_LATE_FEE_APR_BIPS, "escrow: late fee APR too high");
-        require(maxGracePeriod >= MIN_GRACE_PERIOD, "escrow: grace period too short");
-        require(maxGracePeriod <= MAX_GRACE_PERIOD, "escrow: grace period too long");
+        require(gracePeriod >= MIN_GRACE_PERIOD, "escrow: grace period too short");
+        require(gracePeriod <= MAX_GRACE_PERIOD, "escrow: grace period too long");
 
         offerId = nextOfferId++;
         offers[offerId] = OfferStored({
             supplier: msg.sender,
             duration: SafeCast.toUint32(duration),
-            maxGracePeriod: SafeCast.toUint32(maxGracePeriod),
+            gracePeriod: SafeCast.toUint32(gracePeriod),
             interestAPR: SafeCast.toUint24(interestAPR),
             lateFeeAPR: SafeCast.toUint24(lateFeeAPR),
             minEscrow: minEscrow,
@@ -233,7 +195,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
         });
         asset.safeTransferFrom(msg.sender, address(this), amount);
         emit OfferCreated(
-            msg.sender, interestAPR, duration, maxGracePeriod, lateFeeAPR, amount, offerId, minEscrow
+            msg.sender, interestAPR, duration, gracePeriod, lateFeeAPR, amount, offerId, minEscrow
         );
     }
 
@@ -278,25 +240,25 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
      * escrowed amount, so the amount to approve is escrowed + fee.
      * @param offerId The ID of the offer to use
      * @param escrowed The amount to escrow
-     * @param fee The upfront interest fee amount. Checked to be sufficient.
-     *   Will be partially refunded if escrow is released before expiration.
+     * @param fees The upfront interest and late fees to hold. Checked to be sufficient.
+     *   Will be partially refunded depending on escrow release time.
      * @param loanId The associated loan ID
      * @return escrowId The ID of the created escrow
      */
-    function startEscrow(uint offerId, uint escrowed, uint fee, uint loanId)
+    function startEscrow(uint offerId, uint escrowed, uint fees, uint loanId)
         external
         whenNotPaused
         returns (uint escrowId)
     {
         // @dev msg.sender auth is checked vs. loansCanOpen in _startEscrow
-        escrowId = _startEscrow(offerId, escrowed, fee, loanId);
+        escrowId = _startEscrow(offerId, escrowed, fees, loanId);
 
         // @dev despite the fact that they partially cancel out, so can be done as just fee transfer,
         // these transfers are the whole point of this contract from product point of view.
         // The transfer events for the full amounts are needed such that the tokens used for the swap
         // in Loans should be "supplier's", and not "borrower's" from CGT tax laws perspective.
         // transfer "borrower's" funds in
-        asset.safeTransferFrom(msg.sender, address(this), escrowed + fee);
+        asset.safeTransferFrom(msg.sender, address(this), escrowed + fees);
         // transfer "supplier's" funds out
         asset.safeTransfer(msg.sender, escrowed);
     }
@@ -313,32 +275,12 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
     function endEscrow(uint escrowId, uint repaid) external whenNotPaused returns (uint toLoans) {
         // @dev msg.sender auth is checked vs. stored loans in _endEscrow
         // shouldRefund is true since this method returns the refund to loans
-        toLoans = _endEscrow(escrowId, getEscrow(escrowId), repaid, true);
+        toLoans = _endEscrow(escrowId, getEscrow(escrowId), repaid);
 
         // transfer in the repaid assets in: original supplier's assets, plus any late fee
         asset.safeTransferFrom(msg.sender, address(this), repaid);
         // release the escrow (with possible loss to the borrower): user's assets + refund - shortfall
         asset.safeTransfer(msg.sender, toLoans);
-    }
-
-    /**
-     * @notice Ends an escrow by paying only late fees, without sending back anything.
-     * This method should be used when loans pays **only** lateFees (during foreclosure),
-     * and needs to avoid dealing with a possible dust refund (that it can get from endEscrow).
-     * @dev In most cases endEscrow (with refund) should be used.
-     * @dev Can only be called by the Loans contract that started the escrow
-     * @param escrowId The ID of the escrow to end
-     * @param repaid The amount repaid, can be more or less than original escrow amount, depending on
-     * late fees (enforced by the loans contract), or position / slippage / default shortfall. The
-     * supplier is guaranteed to withdraw at least the escrow amount + interest fees regardless.
-     */
-    function endEscrowOnlyLateFees(uint escrowId, uint repaid) external whenNotPaused {
-        // @dev msg.sender auth is checked vs. stored loans in _endEscrow.
-        // return value should be 0 so is ignored.
-        _endEscrow(escrowId, getEscrow(escrowId), repaid, false);
-
-        // transfer in the repaid assets in, should be just late fees for this method
-        asset.safeTransferFrom(msg.sender, address(this), repaid);
     }
 
     /**
@@ -353,15 +295,15 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
      * expiration is as is needed for its use.
      * @param releaseEscrowId The ID of the escrow to release
      * @param offerId The ID of the new offer
-     * @param newFee The new interest fee amount
+     * @param newFees The new interest fee amount
      * @param newLoanId The new loan ID
      * @return newEscrowId The ID of the new escrow
-     * @return feeRefund The refunded fee amount from the old escrow's upfront interest
+     * @return feesRefund The refunded fee amount from the old escrow's upfront interest
      */
-    function switchEscrow(uint releaseEscrowId, uint offerId, uint newFee, uint newLoanId)
+    function switchEscrow(uint releaseEscrowId, uint offerId, uint newFees, uint newLoanId)
         external
         whenNotPaused
-        returns (uint newEscrowId, uint feeRefund)
+        returns (uint newEscrowId, uint feesRefund)
     {
         Escrow memory previousEscrow = getEscrow(releaseEscrowId);
         // do not allow expired escrow to be switched since 0 fromLoans is used for _endEscrow
@@ -380,18 +322,17 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
         // The withdrawable for O's supplier comes from the N's offer, not from Loans repayment.
         // The escrowed loans-funds (E) move into the new escrow of the new supplier.
         // fromLoans must be 0, otherwise escrow will be sent to Loans instead of only the fee refund.
-        // shouldRefund is true, since loans expect a possible fee refund.
-        feeRefund = _endEscrow(releaseEscrowId, previousEscrow, 0, true);
+        feesRefund = _endEscrow(releaseEscrowId, previousEscrow, 0);
 
         // N (new escrow): Mint a new escrow from the offer (can be old or new offer).
         // The escrow funds are funds that have been escrowed in the ID being released ("O").
         // The offer is reduced (which is used to repay the previous supplier)
         // A new escrow ID is minted.
-        newEscrowId = _startEscrow(offerId, previousEscrow.escrowed, newFee, newLoanId);
+        newEscrowId = _startEscrow(offerId, previousEscrow.escrowed, newFees, newLoanId);
 
         // fee transfers
-        asset.safeTransferFrom(msg.sender, address(this), newFee);
-        asset.safeTransfer(msg.sender, feeRefund);
+        asset.safeTransferFrom(msg.sender, address(this), newFees);
+        asset.safeTransfer(msg.sender, feesRefund);
 
         emit EscrowsSwitched(releaseEscrowId, newEscrowId);
     }
@@ -418,23 +359,15 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
     }
 
     /**
-     * @notice Emergency function to seize escrow funds after max grace period. Burns the NFT.
-     * WARNING: DO NOT use this is normal circumstances, instead use LoansNFT.forecloseLoan().
-     * This method is only for extreme scenarios to ensure suppliers can always withdraw even if
-     * original LoansNFT is broken / disabled / disallowed by admin.
-     * This method can only be used after the max grace period is elapsed, and does not pay any late fees.
-     * @dev Ideally the owner of the NFT will call LoansNFT.forecloseLoan() which is callable earlier
-     * or pays late fees (or both). If they do that, "released" will be set to true, disabling this method.
-     * In the opposite situation, if the NFT owner chooses to call this method by mistake,
-     * the LoansNFT method will not be callable, because "released" will true (+NFT will be burned).
+     * @notice Seize escrow funds and any fees held after grace period end. Burns the NFT.
      * @param escrowId The ID of the escrow to seize
      */
-    function lastResortSeizeEscrow(uint escrowId) external whenNotPaused {
+    function seizeEscrow(uint escrowId) external whenNotPaused {
         require(msg.sender == ownerOf(escrowId), "escrow: not escrow owner"); // will revert for burned
 
         Escrow memory escrow = getEscrow(escrowId);
         require(!escrow.released, "escrow: already released");
-        uint gracePeriodEnd = escrow.expiration + escrow.maxGracePeriod;
+        uint gracePeriodEnd = escrow.expiration + escrow.gracePeriod;
         require(block.timestamp > gracePeriodEnd, "escrow: grace period not elapsed");
 
         // update storage
@@ -445,10 +378,10 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
 
         // @dev withdrawal is immediate, so escrow.withdrawable is not set here (no _releaseEscrow call).
         // release escrowed and full interest
-        uint withdrawal = escrow.escrowed + escrow.interestHeld;
+        uint withdrawal = escrow.escrowed + escrow.feesHeld;
         asset.safeTransfer(msg.sender, withdrawal);
 
-        emit EscrowSeizedLastResort(escrowId, msg.sender, withdrawal);
+        emit EscrowSeized(escrowId, msg.sender, withdrawal);
     }
 
     // ----- admin ----- //
@@ -462,7 +395,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
 
     // ----- INTERNAL MUTATIVE ----- //
 
-    function _startEscrow(uint offerId, uint escrowed, uint fee, uint loanId)
+    function _startEscrow(uint offerId, uint escrowed, uint fees, uint loanId)
         internal
         returns (uint escrowId)
     {
@@ -476,9 +409,11 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
         // check params are supported
         require(configHub.isValidCollarDuration(offer.duration), "escrow: unsupported duration");
 
+        (uint expectedFees,,) = upfrontFees(offerId, escrowed);
         // we don't check equality to avoid revert due to minor inaccuracies to the upside,
         // even though exact value should be used from the view.
-        require(fee >= interestFee(offerId, escrowed), "escrow: insufficient fee");
+        // The overpayment is refunded when escrow is properly released (but not when seized).
+        require(fees >= expectedFees, "escrow: insufficient upfront fees");
 
         // check amount
         require(escrowed >= offer.minEscrow, "escrow: amount too low");
@@ -496,12 +431,12 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
             released: false, // unset until release
             loans: msg.sender,
             escrowed: escrowed,
-            interestHeld: fee,
+            feesHeld: fees,
             withdrawable: 0 // unset until release
          });
 
         // emit before token transfer event in mint for easier indexing
-        emit EscrowCreated(escrowId, escrowed, fee, offerId);
+        emit EscrowCreated(escrowId, escrowed, fees, offerId);
         // mint the NFT to the supplier
         // @dev does not use _safeMint to avoid reentrancy
         _mint(offer.supplier, escrowId);
@@ -509,7 +444,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
         emit OfferUpdated(offerId, offer.supplier, prevOfferAmount, prevOfferAmount - escrowed);
     }
 
-    function _endEscrow(uint escrowId, Escrow memory escrow, uint fromLoans, bool shouldRefund)
+    function _endEscrow(uint escrowId, Escrow memory escrow, uint fromLoans)
         internal
         returns (uint toLoans)
     {
@@ -518,7 +453,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
         require(!escrow.released, "escrow: already released");
 
         uint withdrawable;
-        (withdrawable, toLoans,) = _releaseCalculations(escrow, fromLoans, shouldRefund);
+        (withdrawable, toLoans,) = _releaseCalculations(escrow, fromLoans);
 
         // storage updates
         escrows[escrowId].released = true;
@@ -529,73 +464,71 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
 
     // ----- INTERNAL VIEWS ----- //
 
-    function _releaseCalculations(Escrow memory escrow, uint fromLoans, bool shouldRefund)
+    function _releaseCalculations(Escrow memory escrow, uint fromLoans)
         internal
         view
-        returns (uint withdrawal, uint toLoans, uint interestRefund)
+        returns (uint withdrawal, uint toLoans, uint feesRefund)
     {
-        // What we have available is what we held (escrow + full interest) and fromLoans.
-        // FromLoans should be escrow + lateFee, such that the escrow amounts are
+        // What we have available is what we held (escrow + upfront fees) and fromLoans.
+        // FromLoans should be escrow principal only, such that the escrow amounts are
         // "exchanged" again, and any shortfall reduces the toLoans return amount.
-        // @dev note that withdrawal of at least escrow + interest fee is always guaranteed
-        uint available = escrow.escrowed + escrow.interestHeld + fromLoans;
+        // @dev note that withdrawal of all escrow and fees (interest + late fee) is guaranteed
+        uint available = escrow.escrowed + escrow.feesHeld + fromLoans;
 
-        // calculate and credit the refund to loans if shouldRefund is true, else keep it
-        // @dev shouldRefund should be always true, except if **only** lateFee is paid (in foreclosure scenario).
-        if (shouldRefund) {
-            // this handles under-payment (slippage, default) or over-payment (excessive late fees):
-            // any shortfall is for the borrower (e.g., slippage) - taken out of the escrow funds held
+        feesRefund = _feesRefund(escrow);
 
-            // lateFee is non-zero after MIN_GRACE_PERIOD is over (late close loan / seized escrow)
-            uint lateFee = _lateFee(escrow);
-            // refund due to early release. If late fee is not 0, this is likely 0 (because is after expiry).
-            interestRefund = _interestFeeRefund(escrow);
+        // this handles under-payment (slippage, default) or over-payment (excessive late fees):
+        // any shortfall is for the borrower (e.g., slippage) - taken out of the escrow funds held
+        uint targetWithdrawal = escrow.escrowed + escrow.feesHeld - feesRefund;
 
-            // everything owed: original escrow + (interest held - interest refund) + late fee
-            uint targetWithdrawal = escrow.escrowed + escrow.interestHeld + lateFee - interestRefund;
+        // use as much as possible from available up to target
+        withdrawal = Math.min(available, targetWithdrawal);
+        // refund the rest if anything is left: returned supplier's funds, interestRefund, overpayment.
+        toLoans = available - withdrawal;
 
-            // use as much as possible from available up to target
-            withdrawal = Math.min(available, targetWithdrawal);
-            // refund the rest if anything is left: returned supplier's funds, interestRefund, overpayment.
-            toLoans = available - withdrawal;
-
-            // @dev note 1: interest refund "theoretically" covers some of the late fee shortfall, but
-            // "in practice" this will never happen because either late fees are 0 or interest refund is 0.
-
-            // @dev note 2: for (swtichEscrow, fromLoans is 0, and lateFee is 0, so toLoans is just
-            // the interest refund
-
-            /* @dev note 3: late fees are calculated, but cannot be "enforced" here, and instead Loans is
-            trusted to use the views on this contract to correctly calculate the late fees and grace period
-            to ensure they are not underpaid. This contract needs to trust Loans to do so for these reasons:
-            1. Loans needs to swap the right amount of cash, and has the information needed to calculate the
-            funds available for late fees (withdrawal amount, oracle rate, etc).
-            2. Loans needs swap parameters, and has a keeper authorisation system for access control.
-
-            So while a seizeEscrow() method in this contract *could* call to Loans, the keeper access control +
-            the swap parameters + the reduced-grace-period time (by withdrawal), all make it more sensible to
-            be done via Loans directly. The result is that "principal" is always guaranteed by this contract due
-            to always remaining in it, but correct late fees payment depends on Loans implementation.
-            */
-        } else {
-            // no refund
-            (withdrawal, toLoans, interestRefund) = (available, 0, 0);
-        }
+        // @dev for (swtichEscrow, fromLoans is 0, and lateFee is 0, so toLoans is just the interest refund
     }
 
-    function _lateFee(Escrow memory escrow) internal view returns (uint) {
+    function _upfrontFees(uint offerId, uint escrowed)
+        internal
+        view
+        returns (uint interestFee, uint lateFee)
+    {
+        Offer memory offer = getOffer(offerId);
+        // rounds up against the user
+        interestFee = Math.ceilDiv(escrowed * offer.interestAPR * offer.duration, BIPS_BASE * YEAR);
+        lateFee = Math.ceilDiv(escrowed * offer.lateFeeAPR * offer.gracePeriod, BIPS_BASE * YEAR);
+    }
+
+    function _feesRefund(Escrow memory escrow) internal view returns (uint) {
+        // check how much was held for interest (exl
+        (uint interestHeld, uint lateFeeHeld) = _upfrontFees(escrow.offerId, escrow.escrowed);
+
+        // refund any initial voluntary overpayment of fees. This cannot revert because
+        // is checked on escrow start.
+        uint overpaymentRefund = escrow.feesHeld - interestHeld - lateFeeHeld;
+
+        uint interestRefund = _interestRefund(escrow, interestHeld);
+
+        // lateFee is non-zero after MIN_GRACE_PERIOD is over (late endEscrow())
+        uint lateFeeRefund = lateFeeHeld - _lateFeeOwed(escrow);
+
+        return interestRefund + lateFeeRefund + overpaymentRefund;
+    }
+
+    function _lateFeeOwed(Escrow memory escrow) internal view returns (uint) {
         if (block.timestamp <= escrow.expiration + MIN_GRACE_PERIOD) {
             // grace period cliff
             return 0;
         }
         uint overdue = block.timestamp - escrow.expiration; // counts from expiration despite the cliff
         // cap at specified grace period
-        overdue = Math.min(overdue, escrow.maxGracePeriod);
+        overdue = Math.min(overdue, escrow.gracePeriod);
         // @dev rounds up to prevent avoiding fee using many small positions
         return Math.ceilDiv(escrow.escrowed * escrow.lateFeeAPR * overdue, BIPS_BASE * YEAR);
     }
 
-    function _interestFeeRefund(Escrow memory escrow) internal view returns (uint) {
+    function _interestRefund(Escrow memory escrow, uint interestHeld) internal view returns (uint) {
         uint duration = escrow.duration;
         // elapsed = now - startTime; startTime = expiration - duration
         uint elapsed = block.timestamp + duration - escrow.expiration;
@@ -603,16 +536,10 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
         elapsed = Math.min(elapsed, duration);
         // refund is for time remaining. round down against user.
         // no div-zero due to range checks in ConfigHub
-        uint refund = escrow.interestHeld * (duration - elapsed) / duration;
-
-        /* @dev there is no APR calculation here (APR calc used only on open) because:
-         1. simpler
-         2. avoidance of mismatch due to rounding issues
-         3. actual fee held may be higher (it's checked to be >= APR calculated fee)
-        */
+        uint refund = interestHeld * (duration - elapsed) / duration;
 
         // ensure refund is not full, to prevent free cancellation (griefing, DoS)
-        uint maxRefund = escrow.interestHeld * MAX_FEE_REFUND_BIPS / BIPS_BASE;
+        uint maxRefund = interestHeld * MAX_FEE_REFUND_BIPS / BIPS_BASE;
         return Math.min(refund, maxRefund);
     }
 }

--- a/src/LoansNFT.sol
+++ b/src/LoansNFT.sol
@@ -103,45 +103,6 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         });
     }
 
-    /// @notice The values needed for calling forecloseLoan:
-    /// - available grace period using position cash value available for late fees. For timing the call.
-    /// - the cash amount that will be swapped to underlying for paying late fees. For setting swap parameters.
-    /// @dev Uses oracle price for calculations, reverts if position not settled (and therefore before expiry).
-    /// No validation of loan existing or being active, so can return nonsense values for invalid loans.
-    /// @param loanId The ID of the loan to calculate for
-    /// @return gracePeriod The length of the grace period assuming current oracle price
-    /// @return lateFeeCash The amount of cash that will be swapped to pay late fees assuming
-    /// loan is foreclosed now
-    function foreclosureValues(uint loanId) public view returns (uint gracePeriod, uint lateFeeCash) {
-        ICollarTakerNFT.TakerPosition memory takerPosition = takerNFT.getPosition(_takerId(loanId));
-        // @dev avoid settlement estimation complexity: if position is not settled, estimating
-        // withdrawable funds is unnecessarily complex.
-        // Instead, since positions can and should be settled soon after expiry - require that it is.
-        require(takerPosition.settled, "loans: taker position not settled");
-        uint cashAvailable = takerPosition.withdrawable;
-
-        Loan memory loan = getLoan(loanId);
-        (EscrowSupplierNFT escrowNFT, uint escrowId) = (loan.escrowNFT, loan.escrowId);
-        ITakerOracle oracle = takerNFT.oracle();
-
-        // use current price for estimation of underlying that's available after swapping cashAvailable.
-        uint currentPrice = oracle.currentPrice();
-        // round down is ok since it's against the user (being foreclosed).
-        uint underlyingAmount = oracle.convertToBaseAmount(cashAvailable, currentPrice);
-        // assume all available underlying can be used for fees (escrowNFT will cap between max and min)
-        gracePeriod = escrowNFT.cappedGracePeriod(escrowId, underlyingAmount);
-
-        // calculate the cash amount to be swapped for paying late fee
-        // @dev this means that escrow owner pays swap fees and slippage from late fees, which is fine
-        // since they control the swap during foreclosure, and so should account for it in their offer
-        (, uint lateFee) = escrowNFT.currentOwed(escrowId);
-        // round down is fine since can be known in advance, and escrow owner can choose
-        // reasonable offer values (minEscrow, APR, grace period)
-        lateFeeCash = oracle.convertToQuoteAmount(lateFee, currentPrice);
-        // cap at what's actually available
-        lateFeeCash = Math.min(lateFeeCash, cashAvailable);
-    }
-
     /// @notice Checks whether a swapper is allowed for this contract
     function isAllowedSwapper(address swapper) public view returns (bool) {
         return allowedSwappers.contains(swapper);
@@ -200,7 +161,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
      *     - any extraData the swapper needs to use
      * @param providerOffer The providerNFT and ID of the liquidity offer to use
      * @param escrowOffer The escrowNFT and ID of the escrow offer to use
-     * @param escrowFee The escrow interest fee to be paid upfront
+     * @param escrowFees The escrow interest fee and late fee to be paid / held upfront
      * @return loanId The ID of the minted NFT representing the loan
      * @return providerId The ID of the minted CollarProviderNFT paired with this loan
      * @return loanAmount The actual amount of the loan opened in cash asset
@@ -211,10 +172,10 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         SwapParams calldata swapParams,
         ProviderOffer calldata providerOffer,
         EscrowOffer calldata escrowOffer,
-        uint escrowFee
+        uint escrowFees
     ) external whenNotPaused returns (uint loanId, uint providerId, uint loanAmount) {
         return _openLoan(
-            underlyingAmount, minLoanAmount, swapParams, providerOffer, true, escrowOffer, escrowFee
+            underlyingAmount, minLoanAmount, swapParams, providerOffer, true, escrowOffer, escrowFees
         );
     }
 
@@ -385,7 +346,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
      */
     function unwrapAndCancelLoan(uint loanId) external whenNotPaused onlyNFTOwner(loanId) {
         // release escrow if needed with refunds (interest fee) to sender
-        _conditionalCheckAndCancelEscrow(loanId, msg.sender);
+        _conditionalCheckAndCancelEscrow(loanId);
 
         // burn token. This prevents any further calls for this loan
         _burn(loanId);
@@ -394,107 +355,6 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         takerNFT.transferFrom(address(this), msg.sender, _takerId(loanId));
 
         emit LoanCancelled(loanId, msg.sender);
-    }
-
-    /**
-     * @notice Forecloses an escrow loan, that was not repaid on time, after grace period is finished.
-     * The max grace period and its late-fee APR is determined by the initial supplier's offer.
-     * The actual period is dynamically limited by the position's value, to reduce late-fee underpayment.
-     * Uses foreclosureValues() to calculate both the timing and the amount of cash to swap for paying
-     * late fees. Any remaining cash is transferred directly to the borrower, any underlying dust from
-     * late fee repayment (resulting from overestimation) after the swap is transferred to the escrow
-     * NFT holder.
-     * @dev Can be called only by the escrow owner or an allowed keeper (if authorized by escrow owner)
-     * @param loanId The ID of the loan to foreclose
-     * @param swapParams Swap parameters for cash to underlying conversion for swapping lateFeeCash
-     * as returned by foreclosureValues()
-     */
-    function forecloseLoan(uint loanId, SwapParams calldata swapParams) external whenNotPaused {
-        // get the borrower address here, both to ensure loan is active (will revert otherwise)
-        // and because owner address won't be available after burning the NFT
-        address borrower = ownerOf(loanId);
-
-        Loan memory loan = getLoan(loanId);
-        require(loan.usesEscrow, "loans: not an escrowed loan");
-
-        (EscrowSupplierNFT escrowNFT, uint escrowId) = (loan.escrowNFT, loan.escrowId);
-        // Funds beneficiary (escrow owner) should ideally set the swapParams.
-        // A keeper can be useful because foreclosing can be time-sensitive, due to swap timing
-        // impacting the amount of funds available for late-fee repayment.
-        // @dev will also revert on non-existent (unminted / burned) escrow ID
-        address escrowOwner = escrowNFT.ownerOf(escrowId);
-        require(_isSenderOrKeeperFor(escrowOwner, loanId), "loans: not escrow owner or allowed keeper");
-
-        // @dev foreclosureValues uses oracle-price, while actual swap is using spot price.
-        // This has several implications:
-        // 1. This protects foreclosing timing from price manipulation.
-        // 2. The swap can be manipulated against the supplier, so either they or a trusted keeper
-        //    should call this method (to set the slippage parameters).
-        // 3. This also means that swap amount may be different from the estimation in foreclosureValues().
-        //    In most cases late fees will be slightly underpaid due to this (+slippage and swap fees).
-        (uint gracePeriod, uint lateFeeCash) = foreclosureValues(loanId);
-        require(block.timestamp > _expiration(loanId) + gracePeriod, "loans: cannot foreclose yet");
-
-        // burn NFT from the user. Prevents any further actions for this loan.
-        // Although they are not the caller, altering their assets is fine here because
-        // foreclosing is a state with other negative consequence they should try to avoid anyway
-        _burn(loanId);
-
-        // position was checked to settled already, so we only need to withdraw.
-        // @dev because taker NFT is held by this contract, this could not have been called already
-        uint cashAvailable = takerNFT.withdrawFromSettled(_takerId(loanId));
-
-        /*
-        @dev Swapping **only** the lateFeeCash prevents escrow owner from being able to
-        extract borrower's remaining funds via self-sandwiching the swap.
-        However, this also means that escrow owner pays swap fees and slippage from late fees,
-        which is fine since they control the swap, and should account for it in their offer.
-        @dev this also means that lateFeeCash via foreclosureValues() needs to be used to set
-        set the slippage in swapParams.
-        @dev Reentrancy assumption: no user state writes or reads AFTER the swapper call in _swap.
-        A call to escrowNFT.endEscrow is made after this, but escrow belongs to the caller, and is
-        protected via "released" flag in escrow.
-        */
-        uint fromSwap = _swap(cashAsset, underlying, lateFeeCash, swapParams);
-
-        // release the escrow
-        underlying.forceApprove(address(escrowNFT), fromSwap);
-        /*
-        endEscrowOnlyLateFees is used since we swapped **only** the cash that corresponds to the late fees
-        and so all of the swap output should go to escrow owner regardless of swap price.
-        There can be no interest fee refund because this happens after expiration.
-        If regular endEscrow would be used, there could be a refund due to oracle and spot price
-        difference, but this refund would need to be then sent to the escrow owner anyway, so this
-        method avoids the need to split the funds, and do a direct transfer outside of withdrawal flow.
-        */
-        escrowNFT.endEscrowOnlyLateFees(escrowId, fromSwap);
-
-        // any cash remaining after paying late fees is refunded to the borrower
-        // @dev cannot underflow because lateFeeCash is capped to cashAvailable in foreclosureValues
-        uint cashToBorrower = cashAvailable - lateFeeCash;
-
-        /*
-        Withdrawal pull-pattern is neglected here due to:
-        1) It's the responsibility of the NFT owner to avoid foreclosure so if the NFT is in some
-        contract that won't attribute these funds, it's the borrower's fault for being in an undesirable
-        state of being foreclosed due to not repaying on time
-        2) To avoid making the contract hold funds (useful assumption in other places)
-        3) For simplicity, as this flow is already very complex
-
-        Regarding blocked transfers. In most cases, either the cashToBorrower is 0 (and so no
-        transfer will be done), or if the cashToBorrower is non-zero after deducting late fees,
-        we're at maxGracePeriod end, and max late fee accumulation point.
-        This is a scenario the borrower would want to avoid in the first place and instead
-        cancel / close / roll in time to receive as much of the full cashAvailable as possible.
-        Still, if this transfer is blocked, it can only be at the end of maxGracePeriod and, and
-        escrow owner can call lastResortSeizeEscrow() then. While they don't get the late fees,
-        the borrower likely lost an even larger amount of funds, which makes the scenario implausible.
-        */
-        if (cashToBorrower != 0) {
-            cashAsset.safeTransfer(borrower, cashToBorrower);
-        }
-
-        emit LoanForeclosed(loanId, escrowId, fromSwap, cashToBorrower);
     }
 
     /**
@@ -547,7 +407,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         ProviderOffer calldata providerOffer,
         bool usesEscrow,
         EscrowOffer memory escrowOffer,
-        uint escrowFee
+        uint escrowFees
     ) internal returns (uint loanId, uint providerId, uint loanAmount) {
         require(configHub.canOpenPair(underlying, cashAsset, address(this)), "loans: unsupported loans");
         // taker NFT and provider NFT canOpen is checked in _swapAndMintPaired
@@ -555,13 +415,13 @@ contract LoansNFT is ILoansNFT, BaseNFT {
 
         // sanitize escrowFee in case usesEscrow is false.
         // Redundant since depends on internal logic, but more consistent with rest of escrow logic
-        escrowFee = usesEscrow ? escrowFee : 0;
+        escrowFees = usesEscrow ? escrowFees : 0;
         // @dev pull underlyingAmount and escrowFee
-        underlying.safeTransferFrom(msg.sender, address(this), underlyingAmount + escrowFee);
+        underlying.safeTransferFrom(msg.sender, address(this), underlyingAmount + escrowFees);
 
         // handle optional escrow, must be done first, to use "supplier's" underlying in swap
         (EscrowSupplierNFT escrowNFT, uint escrowId) =
-            _conditionalOpenEscrow(usesEscrow, underlyingAmount, escrowOffer, escrowFee);
+            _conditionalOpenEscrow(usesEscrow, underlyingAmount, escrowOffer, escrowFees);
 
         // stack too deep
         {
@@ -778,7 +638,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
 
     // ----- Conditional escrow mutative methods ----- //
 
-    function _conditionalOpenEscrow(bool usesEscrow, uint escrowed, EscrowOffer memory offer, uint fee)
+    function _conditionalOpenEscrow(bool usesEscrow, uint escrowed, EscrowOffer memory offer, uint fees)
         internal
         returns (EscrowSupplierNFT escrowNFT, uint escrowId)
     {
@@ -790,11 +650,11 @@ contract LoansNFT is ILoansNFT, BaseNFT {
             require(configHub.canOpenSingle(underlying, address(escrowNFT)), "loans: unsupported escrow");
 
             // @dev underlyingAmount and fee were pulled already before calling this method
-            underlying.forceApprove(address(escrowNFT), escrowed + fee);
+            underlying.forceApprove(address(escrowNFT), escrowed + fees);
             escrowId = escrowNFT.startEscrow({
                 offerId: offer.id,
                 escrowed: escrowed,
-                fee: fee,
+                fees: fees,
                 loanId: takerNFT.nextPositionId() // @dev checked later in _escrowValidations
              });
             // @dev no balance checks because contract holds no funds, mismatch will cause reverts
@@ -804,7 +664,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
     }
 
     /// @dev escrow switch during roll
-    function _conditionalSwitchEscrow(Loan memory prevLoan, uint offerId, uint newLoanId, uint newFee)
+    function _conditionalSwitchEscrow(Loan memory prevLoan, uint offerId, uint newLoanId, uint newFees)
         internal
         returns (uint newEscrowId)
     {
@@ -813,13 +673,13 @@ contract LoansNFT is ILoansNFT, BaseNFT {
             // check this escrow is still allowed
             require(configHub.canOpenSingle(underlying, address(escrowNFT)), "loans: unsupported escrow");
 
-            underlying.safeTransferFrom(msg.sender, address(this), newFee);
-            underlying.forceApprove(address(escrowNFT), newFee);
-            uint feeRefund;
-            (newEscrowId, feeRefund) = escrowNFT.switchEscrow({
+            underlying.safeTransferFrom(msg.sender, address(this), newFees);
+            underlying.forceApprove(address(escrowNFT), newFees);
+            uint feesRefund;
+            (newEscrowId, feesRefund) = escrowNFT.switchEscrow({
                 releaseEscrowId: prevLoan.escrowId,
                 offerId: offerId,
-                newFee: newFee,
+                newFees: newFees,
                 newLoanId: newLoanId
             });
 
@@ -827,7 +687,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
             _escrowValidations(newLoanId, escrowNFT, newEscrowId);
 
             // send potential interest fee refund
-            underlying.safeTransfer(msg.sender, feeRefund);
+            underlying.safeTransfer(msg.sender, feesRefund);
         } else {
             // returns default empty value
         }
@@ -838,81 +698,71 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         if (loan.usesEscrow) {
             (EscrowSupplierNFT escrowNFT, uint escrowId) = (loan.escrowNFT, loan.escrowId);
 
-            // get owing and late fee (included in totalOwed)
-            (uint totalOwed, uint lateFee) = escrowNFT.currentOwed(escrowId);
-
-            /* Ensure caller when closing didn't self-sandwich the swap to underpay lateFees.
-            If the late fees are higher than the a legitimate (unmanipulated) swap amount when closing,
-            the user would not call close anyway - since they would get no underlying out for
-            their repayment, so this check is not creating a DoS for that case.
-            */
-            require(fromSwap >= lateFee, "loans: fromSwap < lateFee");
-
+            // only need to return escrowed, since fees were paid / held upfront
+            uint escrowed = escrowNFT.getEscrow(escrowId).escrowed;
             // if owing more than swapped, use all, otherwise just what's owed
-            uint toEscrow = Math.min(fromSwap, totalOwed);
+            uint toEscrow = Math.min(fromSwap, escrowed);
             // if owing less than swapped, left over gains are for the borrower
             uint leftOver = fromSwap - toEscrow;
 
             underlying.forceApprove(address(escrowNFT), toEscrow);
-            // fromEscrow is what escrow returns after deducting any shortfall.
-            // (although not problematic, there should not be any interest fee refund here,
-            // because this method is called after expiry).
-            // a refund is expected since escrow should return the user's original funds (minus shortfall)
+            // fromEscrow is what escrow returns after deducting any shortfall and adding refunds:
+            // - a refund of principal is expected since escrow should return the user's
+            // original funds (minus shortfall)
+            // - should be a late fee refund (full or partial), if before end of grace period
+            // - should not be any interest fee refund here, because this is after expiry
             uint fromEscrow = escrowNFT.endEscrow(escrowId, toEscrow);
             // @dev no balance checks because contract holds no funds, mismatch will cause reverts
 
             // the released and the leftovers to be sent to borrower. Zero-value-transfer is allowed
             underlyingOut = fromEscrow + leftOver;
 
-            emit EscrowSettled(escrowId, lateFee, toEscrow, fromEscrow, leftOver);
+            emit EscrowSettled(escrowId, toEscrow, fromEscrow, leftOver);
         } else {
             underlyingOut = fromSwap;
         }
     }
 
-    function _conditionalCheckAndCancelEscrow(uint loanId, address refundRecipient) internal {
+    function _conditionalCheckAndCancelEscrow(uint loanId) internal {
         Loan memory loan = getLoan(loanId);
         // only check and release if escrow was used
         if (loan.usesEscrow) {
             (EscrowSupplierNFT escrowNFT, uint escrowId) = (loan.escrowNFT, loan.escrowId);
             bool escrowReleased = escrowNFT.getEscrow(escrowId).released;
-            /* Allow two cases:
+            /* Allow cancelling in all cases. Handle unreleased escrow if needed.
 
-            1. Escrow was released: to handle the case of escrow owner
-              calling escrowNFT.lastResortSeizeEscrow() instead of loans.forecloseLoan() for any reason.
+            1. If escrow was released: no-op to handle the case of escrow owner
+              calling escrowNFT.seizeEscrow() after end of grace period.
               In that case, none of the other methods are callable because escrow is released
               already, and user is very late to close, the simplest thing that can be done to
               avoid locking user's funds is to cancel the loan and send them the takerId to withdraw cash.
 
-            2. Loan NOT after expiry. This to prevent frontrunning foreclosing if after expiry (and min grace).
-              After expiry either the user should call closeLoan(), or escrow owner should
-              call forecloseLoan().
+            2. Not released, prior to expiry.
 
-            Note that 2 doesn't allow unwrapping during min-grace-period, despite late-fee being zero then.
-            This is because the grace period's purpose is to allow the user to control the swap,
-            not to prolong their expiry. This is in exchange for accumulating late fees, accumulated
-            from expiry (with a cliff). Allowing the user to unwrap then will grief the supplier.
-            This would be relevant in case the user position has some dust cash in it - not enough
-            to justify repaying (due to slippage on full amount). In such a case user should unwrap
-            before expiry, or allow the dust to go to the escrow supplier.
+            3. Not released, after expiry. Late fees will be accounted by the escrow contract.
 
-            Note that this does not allow cancelling after expiry if escrow owner disappears and never calls
-            either foreclose or seize. In that scenario the borrower can only call closeLoan, but cannot cancel.
+            Note that 3 allows unwrapping during min-grace-period, despite late-fee being zero then.
+            This allows the borrower to wait until the min-grace end to cancel, which delays the escrow
+            without compensating with late fees. However, this is symmetric to them being able to close
+            during that period without paying late fees. Escrow owners should take this into account
+            when calculating their offer terms. Alternatively, a different escrow implementation can
+            use different logic: for example, a shorter, or no min-grace period, or can charge regular
+            interest during it.
             */
-            require(escrowReleased || block.timestamp <= _expiration(loanId), "loans: loan expired");
 
             if (!escrowReleased) {
                 // if not released, release the user funds to the supplier since the user will not repay
-                // the loan. There's no late fees - loan has not expired, but also no repayment - there was
-                // no swap. There may be an interest fee refund for the borrower.
+                // the loan. Late fees are held upfront if relevant. There's no repayment - there was
+                // no swap. There may be an interest fee refund for the borrower (if before expiry).
                 // @dev In immediate cancellation: NOT all escrow fee is refunded. A minimal fee is ensured
                 // to prevent DoS of escrow offers by cycling them into withdrawals.
-                // A refund is expected since escrow should return an interest fee refund if available.
                 uint feeRefund = escrowNFT.endEscrow(escrowId, 0);
                 // @dev no balance checks because contract holds no funds, mismatch will cause reverts
 
-                // send potential interest fee refund
-                underlying.safeTransfer(refundRecipient, feeRefund);
+                // send potential refunds
+                underlying.safeTransfer(msg.sender, feeRefund);
+
+                emit EscrowSettled(escrowId, 0, feeRefund, 0);
             }
         }
     }

--- a/src/LoansNFT.sol
+++ b/src/LoansNFT.sol
@@ -339,7 +339,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
     /**
      * @notice Cancels an active loan, burns the loan NFT, and unwraps the taker NFT to user,
      * disconnecting it from the loan.
-     * If escrow was used, checks releases the escrow if it wasn't released and sends any
+     * If escrow was used, releases the escrow if it wasn't released and sends any
      * escrow fee refunds to the caller.
      * @param loanId The ID representing the loan to unwrap and cancel
      */
@@ -540,7 +540,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
         require(isAllowedSwapper(swapParams.swapper), "loans: swapper not allowed");
 
         // @dev 0 amount swaps may revert (depending on swapper), short-circuit here instead of in
-        // swappers to: reduce surface area for integration issues, gas.
+        // swappers to: reduce surface area for integration issues.
         if (amountIn == 0) {
             amountOut = 0;
         } else {

--- a/src/interfaces/IEscrowSupplierNFT.sol
+++ b/src/interfaces/IEscrowSupplierNFT.sol
@@ -8,10 +8,10 @@ interface IEscrowSupplierNFT {
     struct OfferStored {
         // packed first slot
         uint32 duration;
-        uint32 maxGracePeriod;
+        uint32 gracePeriod;
         uint24 interestAPR; // allows up to 167,772%, must allow MAX_INTEREST_APR_BIPS
         uint24 lateFeeAPR; // allows up to 167,772%, must allow MAX_LATE_FEE_APR_BIPS
-        // Note that `maxGracePeriod` can also be u24 (194 days), and `interestAPR` can be u16 (650%) and
+        // Note that `gracePeriod` can also be u24 (194 days), and `interestAPR` can be u16 (650%) and
         // they will all fit into one slot with provider, but the impact is minimal, so not worth the
         // messiness (coupling, mental overhead).
         // second slot
@@ -27,7 +27,7 @@ interface IEscrowSupplierNFT {
         // terms
         uint duration;
         uint interestAPR;
-        uint maxGracePeriod;
+        uint gracePeriod;
         uint lateFeeAPR;
         uint minEscrow;
     }
@@ -42,7 +42,7 @@ interface IEscrowSupplierNFT {
         address loans;
         // rest of slots
         uint escrowed;
-        uint interestHeld;
+        uint feesHeld;
         uint withdrawable;
     }
 
@@ -53,12 +53,12 @@ interface IEscrowSupplierNFT {
         uint loanId;
         // terms
         uint escrowed;
-        uint maxGracePeriod;
+        uint gracePeriod;
         uint lateFeeAPR;
         // interest & refund
         uint duration;
         uint expiration;
-        uint interestHeld;
+        uint feesHeld;
         // withdrawal
         bool released;
         uint withdrawable;
@@ -69,17 +69,17 @@ interface IEscrowSupplierNFT {
         address indexed supplier,
         uint indexed interestAPR,
         uint indexed duration,
-        uint maxGracePeriod,
+        uint gracePeriod,
         uint lateFeeAPR,
         uint available,
         uint offerId,
         uint minEscrow
     );
     event OfferUpdated(uint indexed offerId, address indexed supplier, uint previousAmount, uint newAmount);
-    event EscrowCreated(uint indexed escrowId, uint indexed amount, uint interestFee, uint offerId);
+    event EscrowCreated(uint indexed escrowId, uint indexed amount, uint feesHeld, uint offerId);
     event EscrowReleased(uint indexed escrowId, uint fromLoans, uint withdrawable, uint toLoans);
     event EscrowsSwitched(uint indexed oldEscrowId, uint indexed newEscrowId);
     event WithdrawalFromReleased(uint indexed escrowId, address indexed recipient, uint withdrawn);
-    event EscrowSeizedLastResort(uint indexed escrowId, address indexed recipient, uint withdrawn);
+    event EscrowSeized(uint indexed escrowId, address indexed recipient, uint withdrawn);
     event LoansCanOpenSet(address indexed loansAddress, bool indexed allowed);
 }

--- a/src/interfaces/ILoansNFT.sol
+++ b/src/interfaces/ILoansNFT.sol
@@ -82,6 +82,5 @@ interface ILoansNFT {
     event ClosingKeeperApproved(address indexed sender, uint indexed loanId, bool indexed enabled);
     event ClosingKeeperUpdated(address indexed previousKeeper, address indexed newKeeper);
     event SwapperSet(address indexed swapper, bool indexed allowed, bool indexed setDefault);
-    event EscrowSettled(uint indexed escrowId, uint lateFee, uint toEscrow, uint fromEscrow, uint leftOver);
-    event LoanForeclosed(uint indexed loanId, uint indexed escrowId, uint fromSwap, uint cashToBorrower);
+    event EscrowSettled(uint indexed escrowId, uint toEscrow, uint fromEscrow, uint leftOver);
 }

--- a/test/integration/arbitrum-mainnet/BaseForkTest.sol
+++ b/test/integration/arbitrum-mainnet/BaseForkTest.sol
@@ -212,7 +212,7 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         internal
         returns (uint loanId, uint providerId, uint loanAmount)
     {
-        uint expectedEscrowFee = pair.escrowNFT.interestFee(escrowOfferId, underlyingAmount);
+        uint expectedEscrowFee = pair.escrowNFT.upfrontFees(escrowOfferId, underlyingAmount);
 
         // Open escrow loan using base function
         (loanId, providerId, loanAmount) = openEscrowLoan(
@@ -231,7 +231,7 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         uint escrowSupplierUnderlyingBefore,
         uint expectedProtocolFee
     ) internal view {
-        uint expectedEscrowFee = pair.escrowNFT.interestFee(escrowOfferId, underlyingAmount);
+        uint expectedEscrowFee = pair.escrowNFT.upfrontFees(escrowOfferId, underlyingAmount);
 
         uint userUnderlyingBefore = pair.underlying.balanceOf(user) + underlyingAmount + expectedEscrowFee;
 
@@ -331,7 +331,7 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         ILoansNFT.Loan memory loanBefore = pair.loansContract.getLoan(loanId);
 
         uint escrowSupplierBefore = pair.underlying.balanceOf(escrowSupplier);
-        uint interestFee = pair.escrowNFT.interestFee(escrowOfferId, underlyingAmount);
+        uint interestFee = pair.escrowNFT.upfrontFees(escrowOfferId, underlyingAmount);
 
         // Skip to expiry
         skip(duration);
@@ -358,7 +358,7 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
     function testRollEscrowLoanBetweenSuppliers() public {
         // Create first provider and escrow offers
         (uint offerId1, uint escrowOfferId1) = createEscrowOffers();
-        uint interestFee1 = pair.escrowNFT.interestFee(escrowOfferId1, underlyingAmount);
+        uint interestFee1 = pair.escrowNFT.upfrontFees(escrowOfferId1, underlyingAmount);
 
         uint userUnderlyingBefore = pair.underlying.balanceOf(user);
         (uint loanId, uint providerId,) = executeEscrowLoan(offerId1, escrowOfferId1);
@@ -394,7 +394,7 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         // Create roll offer using existing provider position
         uint rollOfferId = createRollOffer(pair, provider, loanId, providerId, rollFee, rollDeltaFactor);
 
-        uint newEscrowFee = pair.escrowNFT.interestFee(escrowOfferId2, underlyingAmount);
+        uint newEscrowFee = pair.escrowNFT.upfrontFees(escrowOfferId2, underlyingAmount);
         uint userUnderlyingBeforeRoll = pair.underlying.balanceOf(user);
 
         vm.startPrank(user);

--- a/test/integration/arbitrum-mainnet/BaseForkTest.sol
+++ b/test/integration/arbitrum-mainnet/BaseForkTest.sol
@@ -154,6 +154,13 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
 
     BaseDeployer.AssetPairContracts internal pair;
 
+    // restores back to snapshot for tests that skip time ahead
+    modifier restoreSnapshot() {
+        uint vmSnapshot = vm.snapshotState();
+        _;
+        vm.revertToState(vmSnapshot);
+    }
+
     function setUp() public virtual override {
         super.setUp();
 
@@ -286,7 +293,7 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         assertEq(oraclePrice, pair.takerNFT.currentOraclePrice());
     }
 
-    function testOpenAndCloseLoan() public {
+    function testOpenAndCloseLoan() public restoreSnapshot {
         uint providerBalanceBefore = pair.cashAsset.balanceOf(provider);
         uint offerId = createProviderOffer(pair, callstrikeToUse, offerAmount, duration, ltv);
         assertEq(pair.cashAsset.balanceOf(provider), providerBalanceBefore - offerAmount);
@@ -327,7 +334,7 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         );
     }
 
-    function testOpenAndCloseEscrowLoan() public {
+    function testOpenAndCloseEscrowLoan() public restoreSnapshot {
         //  create provider and escrow offers
         (uint offerId, uint escrowOfferId) = createEscrowOffers();
         (uint loanId,, uint loanAmount) = executeEscrowLoan(offerId, escrowOfferId);
@@ -364,7 +371,7 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         assertEq(pair.underlying.balanceOf(user) - userBefore, underlyingOut);
     }
 
-    function testRollEscrowLoanBetweenSuppliers() public {
+    function testRollEscrowLoanBetweenSuppliers() public restoreSnapshot {
         // Create first provider and escrow offers
         (uint offerId1, uint escrowOfferId1) = createEscrowOffers();
         (uint escrowFees1,,) = pair.escrowNFT.upfrontFees(escrowOfferId1, underlyingAmount);
@@ -504,7 +511,7 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         assertGe(int(newLoanAmount), int(initialLoanAmount) + transferAmount);
     }
 
-    function testFullLoanLifecycle() public {
+    function testFullLoanLifecycle() public restoreSnapshot {
         uint feeRecipientBalanceBefore = pair.cashAsset.balanceOf(feeRecipient);
 
         uint offerId = createProviderOffer(pair, callstrikeToUse, offerAmount, duration, ltv);
@@ -583,7 +590,7 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         assertEq(pair.underlying.balanceOf(user) - userUnderlyingBefore, underlyingOut);
     }
 
-    function testCloseEscrowLoanAfterGracePeriod() public {
+    function testCloseEscrowLoanAfterGracePeriod() public restoreSnapshot {
         //  create provider and escrow offers
         (uint offerId, uint escrowOfferId) = createEscrowOffers();
         (uint loanId,, uint loanAmount) = executeEscrowLoan(offerId, escrowOfferId);
@@ -626,7 +633,7 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         assertEq(pair.underlying.balanceOf(user) - userBefore, underlyingOut);
     }
 
-    function testSeizeEscrowAndUnwrapLoan() public {
+    function testSeizeEscrowAndUnwrapLoan() public restoreSnapshot {
         //  create provider and escrow offers
         (uint offerId, uint escrowOfferId) = createEscrowOffers();
         (uint loanId,,) = executeEscrowLoan(offerId, escrowOfferId);
@@ -666,7 +673,7 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         assertEq(pair.cashAsset.balanceOf(user) - userBeforeCash, takerWithdrawal);
     }
 
-    function testCloseEscrowLoanWithPartialLateFees() public {
+    function testCloseEscrowLoanWithPartialLateFees() public restoreSnapshot {
         //  create provider and escrow offers
         (uint offerId, uint escrowOfferId) = createEscrowOffers();
         (uint loanId,, uint loanAmount) = executeEscrowLoan(offerId, escrowOfferId);

--- a/test/integration/arbitrum-mainnet/FullProtocol.t.sol
+++ b/test/integration/arbitrum-mainnet/FullProtocol.t.sol
@@ -56,18 +56,6 @@ contract ArbitrumMainnetFullProtocolForkTest is Test, ArbitrumMainnetDeployer {
         validator.test_validatePairDeployments();
     }
 
-    //    function testPriceMovementFlow_aboveCallStrike() public {
-    //        setupLoansForkTest().testSettlementPriceAboveCallStrike();
-    //    }
-
-    //    function testPriceMovementFlow_belowPutStrike() public {
-    //        setupLoansForkTest().testSettlementPriceBelowPutStrike();
-    //    }
-
-    //    function testPriceMovementFlow_upBetweenStrikes() public {
-    //        setupLoansForkTest().testSettlementPriceUpBetweenStrikes();
-    //    }
-
     function testFullIntegration() public {
         WETHUSDCLoansForkTest loansTest = setupLoansForkTest();
         console.log("Running full integration test...");
@@ -83,8 +71,9 @@ contract ArbitrumMainnetFullProtocolForkTest is Test, ArbitrumMainnetDeployer {
         WETHUSDCLoansForkTest loansTest = setupLoansForkTest();
         loansTest.testOpenEscrowLoan();
         loansTest.testOpenAndCloseEscrowLoan();
-        //        loansTest.testCloseEscrowLoanAfterGracePeriod();
-        //        loansTest.testCloseEscrowLoanWithPartialLateFees();
+        loansTest.testCloseEscrowLoanAfterGracePeriod();
+        loansTest.testSeizeEscrowAndUnwrapLoan();
+        loansTest.testCloseEscrowLoanWithPartialLateFees();
         loansTest.testRollEscrowLoanBetweenSuppliers();
     }
 }

--- a/test/unit/EscrowSupplier.admin.t.sol
+++ b/test/unit/EscrowSupplier.admin.t.sol
@@ -77,7 +77,7 @@ contract EscrowSupplierNFT_AdminTest is BaseEscrowSupplierNFTTest {
         escrowNFT.withdrawReleased(0);
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
-        escrowNFT.lastResortSeizeEscrow(0);
+        escrowNFT.seizeEscrow(0);
 
         // transfers are paused
         vm.expectRevert(Pausable.EnforcedPause.selector);

--- a/test/unit/EscrowSupplier.admin.t.sol
+++ b/test/unit/EscrowSupplier.admin.t.sol
@@ -68,9 +68,6 @@ contract EscrowSupplierNFT_AdminTest is BaseEscrowSupplierNFTTest {
         escrowNFT.endEscrow(0, 0);
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
-        escrowNFT.endEscrowOnlyLateFees(0, 0);
-
-        vm.expectRevert(Pausable.EnforcedPause.selector);
         escrowNFT.switchEscrow(0, 0, 0, 0);
 
         vm.expectRevert(Pausable.EnforcedPause.selector);

--- a/test/unit/EscrowSupplier.admin.t.sol
+++ b/test/unit/EscrowSupplier.admin.t.sol
@@ -43,7 +43,7 @@ contract EscrowSupplierNFT_AdminTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_paused_methods() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying, escrowFee);
 
         // pause
         vm.startPrank(owner);

--- a/test/unit/EscrowSupplierNFT.reverts.t.sol
+++ b/test/unit/EscrowSupplierNFT.reverts.t.sol
@@ -62,7 +62,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         vm.expectRevert("escrow: amount too high");
         escrowNFT.startEscrow(offerId, largeAmount + 1, 1 ether, 1000);
 
-        uint minFee = escrowNFT.interestFee(offerId, largeAmount);
+        uint minFee = escrowNFT.upfrontFees(offerId, largeAmount);
         vm.expectRevert("escrow: insufficient fee");
         escrowNFT.startEscrow(offerId, largeAmount, minFee - 1, 1000);
 
@@ -105,7 +105,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         asset.approve(address(escrowNFT), largeAmount);
 
         (uint newOfferId,) = createAndCheckOffer(supplier2, largeAmount - 1);
-        uint minFee = escrowNFT.interestFee(newOfferId, largeAmount - 1);
+        uint minFee = escrowNFT.upfrontFees(newOfferId, largeAmount - 1);
 
         // fee
         startHoax(loans);
@@ -277,12 +277,12 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
 
         startHoax(supplier2);
         vm.expectRevert("escrow: not escrow owner");
-        escrowNFT.lastResortSeizeEscrow(escrowId);
+        escrowNFT.seizeEscrow(escrowId);
 
         skip(duration + maxGracePeriod);
         startHoax(supplier1);
         vm.expectRevert("escrow: grace period not elapsed");
-        escrowNFT.lastResortSeizeEscrow(escrowId);
+        escrowNFT.seizeEscrow(escrowId);
 
         // release
         startHoax(loans);
@@ -292,6 +292,6 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         skip(1);
         startHoax(supplier1);
         vm.expectRevert("escrow: already released");
-        escrowNFT.lastResortSeizeEscrow(escrowId);
+        escrowNFT.seizeEscrow(escrowId);
     }
 }

--- a/test/unit/EscrowSupplierNFT.reverts.t.sol
+++ b/test/unit/EscrowSupplierNFT.reverts.t.sol
@@ -13,7 +13,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
 
         uint val = escrowNFT.MAX_INTEREST_APR_BIPS();
         vm.expectRevert("escrow: interest APR too high");
-        escrowNFT.createOffer(largeUnderlying, duration, val + 1, maxGracePeriod, lateFeeAPR, 0);
+        escrowNFT.createOffer(largeUnderlying, duration, val + 1, gracePeriod, lateFeeAPR, 0);
 
         val = escrowNFT.MIN_GRACE_PERIOD();
         vm.expectRevert("escrow: grace period too short");
@@ -25,7 +25,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
 
         val = escrowNFT.MAX_LATE_FEE_APR_BIPS();
         vm.expectRevert("escrow: late fee APR too high");
-        escrowNFT.createOffer(largeUnderlying, duration, interestAPR, maxGracePeriod, val + 1, 0);
+        escrowNFT.createOffer(largeUnderlying, duration, interestAPR, gracePeriod, val + 1, 0);
     }
 
     function test_revert_updateOfferAmount_notSupplier() public {
@@ -45,7 +45,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         escrowNFT.startEscrow(offerId, 0, 0, 0);
 
         minEscrow = largeUnderlying / 2;
-        uint fee = 1 ether;
+        uint fee = escrowFee;
         (offerId,) = createAndCheckOffer(supplier1, largeUnderlying);
         startHoax(loans);
         asset.approve(address(escrowNFT), largeUnderlying / 2);
@@ -60,7 +60,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         asset.approve(address(escrowNFT), largeUnderlying);
 
         vm.expectRevert("escrow: amount too high");
-        escrowNFT.startEscrow(offerId, largeUnderlying + 1, 1 ether, 1000);
+        escrowNFT.startEscrow(offerId, largeUnderlying + 1, escrowFee, 1000);
 
         (uint minFee,,) = escrowNFT.upfrontFees(offerId, largeUnderlying);
         vm.expectRevert("escrow: insufficient upfront fees");
@@ -73,7 +73,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         configHub.setCollarDurationRange(duration + 1, duration + 2);
         vm.startPrank(loans);
         vm.expectRevert("escrow: unsupported duration");
-        escrowNFT.startEscrow(offerId, largeUnderlying, 1 ether, 1000);
+        escrowNFT.startEscrow(offerId, largeUnderlying, escrowFee, 1000);
     }
 
     function test_revert_switchEscrow_minEscrow() public {
@@ -90,7 +90,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         vm.expectRevert("escrow: amount too low");
         escrowNFT.switchEscrow(escrowId, offer2, 0, 0);
 
-        uint fee = 1 ether;
+        uint fee = escrowFee;
         asset.approve(address(escrowNFT), largeUnderlying / 2 + fee - 1);
         (escrowId) = escrowNFT.startEscrow(offer1, largeUnderlying / 2 - 1, fee, 0);
         // switch to offer3, does not accept the amount
@@ -99,7 +99,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_revert_switchEscrow_invalidParams() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying, escrowFee);
 
         startHoax(loans);
         asset.approve(address(escrowNFT), largeUnderlying);
@@ -158,7 +158,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         setCanOpenSingle(address(escrowNFT), false);
         vm.startPrank(loans);
         vm.expectRevert("escrow: unsupported escrow");
-        escrowNFT.startEscrow(offerId, largeUnderlying / 2, 1 ether, 1000);
+        escrowNFT.startEscrow(offerId, largeUnderlying / 2, escrowFee, 1000);
 
         setCanOpenSingle(address(escrowNFT), true);
 
@@ -167,16 +167,16 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         escrowNFT.setLoansCanOpen(loans, false);
         vm.startPrank(loans);
         vm.expectRevert("escrow: unauthorized loans contract");
-        escrowNFT.startEscrow(offerId, largeUnderlying / 2, 1 ether, 1000);
+        escrowNFT.startEscrow(offerId, largeUnderlying / 2, escrowFee, 1000);
 
         // some other address
         startHoax(makeAddr("otherLoans"));
         vm.expectRevert("escrow: unauthorized loans contract");
-        escrowNFT.startEscrow(offerId, largeUnderlying / 2, 1 ether, 1000);
+        escrowNFT.startEscrow(offerId, largeUnderlying / 2, escrowFee, 1000);
     }
 
     function test_revert_switchEscrow_unauthorizedLoans() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying, escrowFee);
         (uint newOfferId,) = createAndCheckOffer(supplier2, largeUnderlying);
 
         setCanOpenSingle(address(escrowNFT), false);
@@ -200,7 +200,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_revert_loansCanOpen_only_switchEscrow() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying / 2, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying / 2, escrowFee);
 
         // removing loans canOpen prevents switchEscrow
         vm.startPrank(owner);
@@ -213,7 +213,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_revert_endEscrow_switchEscrow() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying / 2, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying / 2, escrowFee);
 
         // not same loans that started
         vm.startPrank(owner);
@@ -237,7 +237,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_revert_withdrawReleased() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying, escrowFee);
 
         startHoax(supplier2);
         vm.expectRevert("escrow: not escrow owner");
@@ -263,13 +263,13 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_revert_seizeEscrow() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying / 2, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying / 2, escrowFee);
 
         startHoax(supplier2);
         vm.expectRevert("escrow: not escrow owner");
         escrowNFT.seizeEscrow(escrowId);
 
-        skip(duration + maxGracePeriod);
+        skip(duration + gracePeriod);
         startHoax(supplier1);
         vm.expectRevert("escrow: grace period not elapsed");
         escrowNFT.seizeEscrow(escrowId);

--- a/test/unit/Loans.admin.t.sol
+++ b/test/unit/Loans.admin.t.sol
@@ -115,9 +115,6 @@ contract LoansAdminTest is LoansTestBase {
         loans.closeLoan(loanId, defaultSwapParams(0));
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
-        loans.forecloseLoan(loanId, defaultSwapParams(0));
-
-        vm.expectRevert(Pausable.EnforcedPause.selector);
         loans.rollLoan(loanId, rollOffer(0), 0, 0, 0);
 
         vm.expectRevert(Pausable.EnforcedPause.selector);

--- a/test/unit/Loans.basic.effects.t.sol
+++ b/test/unit/Loans.basic.effects.t.sol
@@ -127,7 +127,7 @@ contract LoansTestBase is BaseAssetPairTestSetup {
             underlying.approve(address(escrowNFT), largeAmount);
             escrowOfferId =
                 escrowNFT.createOffer(largeAmount, duration, interestAPR, maxGracePeriod, lateFeeAPR, 0);
-            escrowFee = escrowNFT.interestFee(escrowOfferId, underlyingAmount);
+            escrowFee = escrowNFT.upfrontFees(escrowOfferId, underlyingAmount);
         } else {
             // reset to 0
             escrowOfferId = 0;
@@ -284,11 +284,11 @@ contract LoansTestBase is BaseAssetPairTestSetup {
         assertEq(escrow.loans, address(loans));
         assertEq(escrow.loanId, loanId);
         assertEq(escrow.escrowed, underlyingAmount);
-        assertEq(escrow.maxGracePeriod, maxGracePeriod);
+        assertEq(escrow.gracePeriod, maxGracePeriod);
         assertEq(escrow.lateFeeAPR, lateFeeAPR);
         assertEq(escrow.duration, duration);
         assertEq(escrow.expiration, block.timestamp + duration);
-        assertEq(escrow.interestHeld, expectedEscrowFee);
+        assertEq(escrow.feesHeld, expectedEscrowFee);
         assertEq(escrow.released, false);
         assertEq(escrow.withdrawable, 0);
     }
@@ -669,7 +669,7 @@ contract LoansBasicEffectsTest is LoansTestBase {
             // escrow released
             assertEq(escrowNFT.getEscrow(loan.escrowId).released, true);
             // received refund for half a duration
-            refund = escrowNFT.getEscrow(loan.escrowId).interestHeld / 2;
+            refund = escrowNFT.getEscrow(loan.escrowId).feesHeld / 2;
         }
         assertEq(underlying.balanceOf(user1), balanceBefore + refund);
     }

--- a/test/unit/Loans.basic.effects.t.sol
+++ b/test/unit/Loans.basic.effects.t.sol
@@ -506,7 +506,7 @@ contract LoansBasicEffectsTest is LoansTestBase {
         startHoax(user1);
         // 1 wei underlying
         underlying.approve(address(loans), 1);
-        (uint loanId, , uint loanAmount) =
+        (uint loanId,, uint loanAmount) =
             loans.openLoan(1, 0, defaultSwapParams(0), providerOffer(providerOfferId));
 
         assertEq(loanAmount, 0);

--- a/test/unit/Loans.basic.reverts.t.sol
+++ b/test/unit/Loans.basic.reverts.t.sol
@@ -23,7 +23,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
                 defaultSwapParams(_minSwap),
                 providerOffer(_providerOfferId),
                 escrowOffer(escrowOfferId),
-                escrowFee
+                escrowFees
             );
         } else {
             loans.openLoan(_col, _minLoan, defaultSwapParams(_minSwap), providerOffer(_providerOfferId));
@@ -34,7 +34,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
         maybeCreateEscrowOffer();
 
         vm.startPrank(user1);
-        underlying.approve(address(loans), underlyingAmount + escrowFee);
+        underlying.approve(address(loans), underlyingAmount + escrowFees);
         prepareDefaultSwapToCash();
 
         // 0 underlying
@@ -72,7 +72,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
         // not enough approval for underlying
         vm.startPrank(user1);
         underlying.approve(address(loans), underlyingAmount);
-        expectRevertERC20Allowance(address(loans), underlyingAmount, underlyingAmount + 1 + escrowFee);
+        expectRevertERC20Allowance(address(loans), underlyingAmount, underlyingAmount + 1 + escrowFees);
         openLoan(underlyingAmount + 1, minLoanAmount, 0, offerId);
     }
 
@@ -82,7 +82,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
         prepareSwap(cashAsset, swapCashAmount);
 
         vm.startPrank(user1);
-        underlying.approve(address(loans), underlyingAmount + escrowFee);
+        underlying.approve(address(loans), underlyingAmount + escrowFees);
 
         // balance mismatch
         mockSwapperRouter.setupSwap(swapCashAmount - 1, swapCashAmount);
@@ -109,7 +109,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
 
         // not allowed
         startHoax(user1);
-        underlying.approve(address(loans), underlyingAmount + escrowFee);
+        underlying.approve(address(loans), underlyingAmount + escrowFees);
         vm.expectRevert("loans: swapper not allowed");
         openLoan(underlyingAmount, minLoanAmount, 0, 0);
     }
@@ -127,7 +127,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
         prepareSwap(cashAsset, swapCashAmount);
 
         vm.startPrank(user1);
-        underlying.approve(address(loans), underlyingAmount + escrowFee);
+        underlying.approve(address(loans), underlyingAmount + escrowFees);
 
         // balance mismatch
         mockSwapperRouter.setupSwap(swapCashAmount - 1, swapCashAmount);
@@ -146,7 +146,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
         uint swapOut = prepareDefaultSwapToCash();
 
         vm.startPrank(user1);
-        underlying.approve(address(loans), underlyingAmount + escrowFee);
+        underlying.approve(address(loans), underlyingAmount + escrowFees);
 
         uint highMinLoanAmount = (swapOut * ltv / BIPS_100PCT) + 1; // 1 wei more than ltv
         vm.expectRevert("loans: loan amount too low");
@@ -160,7 +160,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
 
         // prep again
         prepareDefaultSwapToCash();
-        underlying.approve(address(loans), underlyingAmount + escrowFee);
+        underlying.approve(address(loans), underlyingAmount + escrowFees);
 
         vm.mockCall(
             address(takerNFT),

--- a/test/unit/Loans.escrow.effects.t.sol
+++ b/test/unit/Loans.escrow.effects.t.sol
@@ -75,7 +75,7 @@ contract LoansEscrowEffectsTest is LoansBasicEffectsTest {
         // struct
         IEscrowSupplierNFT.Escrow memory escrow = escrowNFT.getEscrow(escrowId);
         assertTrue(escrow.released);
-        assertEq(escrow.withdrawable, escrow.escrowed + escrow.interestHeld + swapOut);
+        assertEq(escrow.withdrawable, escrow.escrowed + escrow.feesHeld + swapOut);
 
         // loan and taker NFTs burned
         expectRevertERC721Nonexistent(loanId);

--- a/test/unit/Loans.escrow.effects.t.sol
+++ b/test/unit/Loans.escrow.effects.t.sol
@@ -23,11 +23,7 @@ contract LoansEscrowEffectsTest is LoansBasicEffectsTest {
         assertFalse(escrowNFT.getEscrow(escrowId).released);
 
         // after expiry
-        skip(duration + maxGracePeriod + 1);
-
-        // cannot release
-        vm.expectRevert("loans: loan expired");
-        loans.unwrapAndCancelLoan(loanId);
+        skip(duration + gracePeriod + 1);
 
         // user balance
         uint userBalance = underlying.balanceOf(user1);

--- a/test/unit/Loans.escrow.effects.t.sol
+++ b/test/unit/Loans.escrow.effects.t.sol
@@ -11,84 +11,11 @@ contract LoansEscrowEffectsTest is LoansBasicEffectsTest {
         openEscrowLoan = true;
     }
 
-    function expectedForeclosureValues(uint loanId, uint price)
-        internal
-        view
-        returns (uint gracePeriod, uint cashAvailable, uint lateFeeCash)
-    {
-        cashAvailable = takerNFT.getPosition({ takerId: loanId }).withdrawable;
-        (, uint lateFee) = escrowNFT.currentOwed(loans.getLoan(loanId).escrowId);
-        uint underlyingAmt = chainlinkOracle.convertToBaseAmount(cashAvailable, price);
-        gracePeriod = escrowNFT.cappedGracePeriod(loans.getLoan(loanId).escrowId, underlyingAmt);
-        lateFeeCash = chainlinkOracle.convertToQuoteAmount(lateFee, price);
-        lateFeeCash = lateFeeCash > cashAvailable ? cashAvailable : lateFeeCash;
-    }
-
-    function checkForecloseLoan(uint settlePrice, uint currentPrice, uint skipAfterGrace, address caller)
-        internal
-        returns (uint swapOut, uint expectedBorrowerRefund)
-    {
-        (uint loanId,,) = createAndCheckLoan();
-
-        skip(duration);
-        updatePrice(settlePrice);
-        // settle
-        takerNFT.settlePairedPosition(loanId);
-
-        // update to currentPrice price
-        updatePrice(currentPrice);
-        // estimate the length of grace period
-        (uint estimatedGracePeriod,) = loans.foreclosureValues(loanId);
-
-        // skip past grace period
-        skip(estimatedGracePeriod + skipAfterGrace);
-        updatePrice(currentPrice);
-        // estimate the cash for late fees
-        (, uint lateFeeCash) = loans.foreclosureValues(loanId);
-
-        uint takerCash = takerNFT.getPosition(loanId).withdrawable;
-        swapOut = chainlinkOracle.convertToBaseAmount(lateFeeCash, currentPrice);
-        prepareSwap(underlying, swapOut);
-
-        // calculate expected escrow release values
-        uint escrowId = loans.getLoan(loanId).escrowId;
-        EscrowReleaseAmounts memory released = getEscrowReleaseValues(escrowId, swapOut);
-        expectedBorrowerRefund = takerCash - lateFeeCash;
-        uint userCashBalance = cashAsset.balanceOf(user1);
-        uint escrowBalance = underlying.balanceOf(address(escrowNFT));
-
-        // check late fee and grace period values
-        assertGe(estimatedGracePeriod, escrowNFT.MIN_GRACE_PERIOD());
-        assertLe(estimatedGracePeriod, maxGracePeriod);
-        assertEq(released.lateFee, expectedLateFees(estimatedGracePeriod + skipAfterGrace));
-
-        // foreclose
-        vm.startPrank(caller);
-        vm.expectEmit(address(loans));
-        emit ILoansNFT.LoanForeclosed(loanId, escrowId, swapOut, expectedBorrowerRefund);
-        loans.forecloseLoan(loanId, defaultSwapParams(0));
-
-        // balances
-        assertEq(cashAsset.balanceOf(user1), userCashBalance + expectedBorrowerRefund);
-        assertEq(underlying.balanceOf(address(escrowNFT)), escrowBalance + swapOut);
-
-        // struct
-        IEscrowSupplierNFT.Escrow memory escrow = escrowNFT.getEscrow(escrowId);
-        assertTrue(escrow.released);
-        assertEq(escrow.withdrawable, escrow.escrowed + escrow.feesHeld + swapOut);
-
-        // loan and taker NFTs burned
-        expectRevertERC721Nonexistent(loanId);
-        loans.ownerOf(loanId);
-        expectRevertERC721Nonexistent(loanId);
-        takerNFT.ownerOf({ tokenId: loanId });
-    }
-
     // tests
 
     // repeat all effects tests (open, close, unwrap) from super, but with escrow
 
-    function test_unwrapAndCancelLoan_after_lastResortSeizeEscrow() public {
+    function test_unwrapAndCancelLoan_after_seizeEscrow() public {
         (uint loanId,,) = createAndCheckLoan();
 
         // check that escrow unreleased
@@ -106,9 +33,9 @@ contract LoansEscrowEffectsTest is LoansBasicEffectsTest {
         uint userBalance = underlying.balanceOf(user1);
         uint loansBalance = underlying.balanceOf(address(loans));
 
-        // release escrow via lastResortSeizeEscrow
+        // release escrow via seizeEscrow
         vm.startPrank(supplier);
-        escrowNFT.lastResortSeizeEscrow(escrowId);
+        escrowNFT.seizeEscrow(escrowId);
         assertTrue(escrowNFT.getEscrow(escrowId).released);
 
         // now can unwrap
@@ -127,163 +54,5 @@ contract LoansEscrowEffectsTest is LoansBasicEffectsTest {
         // cannot cancel again
         expectRevertERC721Nonexistent(loanId);
         loans.unwrapAndCancelLoan(loanId);
-    }
-
-    function test_foreclosureValues_afterExpiry() public {
-        (uint loanId,,) = createAndCheckLoan();
-
-        skip(duration);
-        updatePrice();
-        takerNFT.settlePairedPosition(loanId);
-        // current price is different from settlement
-        oraclePrice = oraclePrice * 11 / 10;
-        updatePrice();
-        (uint expectedPeriod,,) = expectedForeclosureValues(loanId, oraclePrice);
-
-        // after expiry, keeps using correct price
-        skip(1);
-        updatePrice();
-        (uint gracePeriod, uint lateFeeCash) = loans.foreclosureValues(loanId);
-        assertEq(gracePeriod, expectedPeriod);
-        assertEq(lateFeeCash, 0);
-
-        // at last second of grace period
-        skip(escrowNFT.MIN_GRACE_PERIOD() - 1);
-        updatePrice();
-        (gracePeriod, lateFeeCash) = loans.foreclosureValues(loanId);
-        assertEq(gracePeriod, expectedPeriod);
-        assertEq(lateFeeCash, 0);
-
-        // After max grace period
-        skip(escrowNFT.MAX_GRACE_PERIOD());
-        updatePrice();
-        // late fee cash changes with time due to late fee accumulating
-        (,, uint expectedFeeCash) = expectedForeclosureValues(loanId, oraclePrice);
-        (gracePeriod, lateFeeCash) = loans.foreclosureValues(loanId);
-        assertEq(gracePeriod, expectedPeriod);
-        assertEq(lateFeeCash, expectedFeeCash);
-    }
-
-    function test_foreclosureValues_priceChanges() public {
-        (uint loanId,,) = createAndCheckLoan();
-
-        skip(duration); // at expiry
-        updatePrice();
-        takerNFT.settlePairedPosition(loanId);
-        // skip to max grace period for late fee accumulation
-        skip(escrowNFT.MAX_GRACE_PERIOD());
-        updatePrice();
-
-        // Price increase
-        uint highPrice = oraclePrice * 2;
-        updatePrice(highPrice);
-        (uint expectedPeriod, uint cashAvailable, uint expectedFeeCash) =
-            expectedForeclosureValues(loanId, highPrice);
-        (uint gracePeriod, uint lateFeeCash) = loans.foreclosureValues(loanId);
-        assertEq(gracePeriod, expectedPeriod);
-        assertEq(lateFeeCash, expectedFeeCash);
-
-        // Price decrease
-        uint lowPrice = oraclePrice / 2;
-        updatePrice(lowPrice);
-        (expectedPeriod,, expectedFeeCash) = expectedForeclosureValues(loanId, lowPrice);
-        (gracePeriod, lateFeeCash) = loans.foreclosureValues(loanId);
-        assertEq(gracePeriod, expectedPeriod);
-        assertEq(lateFeeCash, expectedFeeCash);
-
-        // min grace period (for very high price), very high price means cash is worth 0 underlying
-        updatePrice(type(uint128).max);
-        (gracePeriod, lateFeeCash) = loans.foreclosureValues(loanId);
-        assertEq(gracePeriod, escrowNFT.MIN_GRACE_PERIOD());
-        assertEq(lateFeeCash, cashAvailable);
-
-        // max grace period (for very low price), because swap will return a lot of underlying
-        uint minPrice = 1;
-        updatePrice(minPrice);
-        (,, expectedFeeCash) = expectedForeclosureValues(loanId, minPrice);
-        (gracePeriod, lateFeeCash) = loans.foreclosureValues(loanId);
-        assertEq(gracePeriod, maxGracePeriod);
-        assertEq(lateFeeCash, expectedFeeCash);
-
-        // worthless position
-        (loanId,,) = createAndCheckLoan();
-        skip(duration); // at expiry
-        updatePrice(minPrice);
-        takerNFT.settlePairedPosition(loanId);
-        (gracePeriod, lateFeeCash) = loans.foreclosureValues(loanId);
-        // position is worth 0 cash, so low underlying price doesn't matter
-        assertEq(gracePeriod, escrowNFT.MIN_GRACE_PERIOD());
-        assertEq(lateFeeCash, 0);
-    }
-
-    function test_forecloseLoan_prices() public {
-        // just after grace period end
-        checkForecloseLoan(oraclePrice, oraclePrice, 1, supplier);
-
-        // long after max gracePeriod
-        checkForecloseLoan(oraclePrice, oraclePrice, maxGracePeriod, supplier);
-
-        // price increase
-        checkForecloseLoan(type(uint128).max, type(uint128).max, maxGracePeriod, supplier);
-
-        // price decrease
-        checkForecloseLoan(1, 1, maxGracePeriod, supplier);
-
-        // price increase, and decrease
-        checkForecloseLoan(largeCash, 1, maxGracePeriod, supplier);
-
-        // price decrease, and increase
-        checkForecloseLoan(1, largeCash, maxGracePeriod, supplier);
-    }
-
-    function test_forecloseLoan_zero_amount_swap() public {
-        (uint swapOut,) = checkForecloseLoan(1, 1, maxGracePeriod, supplier);
-        assertEq(swapOut, 0);
-    }
-
-    function test_forecloseLoan_borrowerRefund() public {
-        // price decrease during swap to get so that little cash is needed to cover late fees
-        // and a large refund is left
-        (, uint borrowerRefund) = checkForecloseLoan(oraclePrice, oraclePrice / 100, maxGracePeriod, supplier);
-        // check borrower should have got something, exact amount is checked in checkForecloseLoan
-        assertNotEq(borrowerRefund, 0);
-    }
-
-    function test_forecloseLoan_borrowerRefund_blockedTransfer() public {
-        // blocked non-zero transfer breaks foreclosure
-        (uint loanId,,) = createAndCheckLoan();
-        skip(duration);
-        updatePrice();
-        takerNFT.settlePairedPosition(loanId);
-        skip(maxGracePeriod + 1);
-        updatePrice();
-
-        // block transfer to user1
-        cashAsset.setBlocked(user1, true);
-        prepareSwap(underlying, underlyingAmount);
-        // a lot of leftovers
-        vm.startPrank(supplier);
-        vm.expectRevert("blocked");
-        loans.forecloseLoan(loanId, defaultSwapParams(0));
-
-        // blocked 0 transfer works fine
-
-        // update to high price such the cash now doesn't buy enough late fees, so all cash is used up
-        updatePrice(type(uint128).max);
-        loans.forecloseLoan(loanId, defaultSwapParams(0));
-    }
-
-    function test_forecloseLoan_byKeeper() public {
-        // Set the keeper
-        vm.startPrank(owner);
-        loans.setKeeper(keeper);
-
-        // Supplier allows the keeper to foreclose
-        vm.startPrank(supplier);
-        // approve keeper for next loan ID, since it will be created in the helper method
-        loans.setKeeperApproved(takerNFT.nextPositionId(), true);
-
-        // by keeper
-        checkForecloseLoan(oraclePrice, oraclePrice, 1, keeper);
     }
 }

--- a/test/unit/Loans.escrow.reverts.t.sol
+++ b/test/unit/Loans.escrow.reverts.t.sol
@@ -129,7 +129,7 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
         vm.expectRevert("escrow: already released");
         escrowNFT.seizeEscrow(escrowId);
 
-        vm.revertTo(checkpoint);
+        vm.revertToState(checkpoint);
         vm.startPrank(user1);
         skip(duration);
         updatePrice();

--- a/test/unit/Loans.escrow.reverts.t.sol
+++ b/test/unit/Loans.escrow.reverts.t.sol
@@ -107,13 +107,13 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
         // seize now
         skip(1);
 
-        // Keeper can now foreclose
+        // escrow can be seized
         vm.startPrank(supplier);
         escrowNFT.seizeEscrow(loan.escrowId);
     }
 
     function test_revert_seizeEscrow_invalidLoanStates() public {
-        // foreclose a non-existent loan
+        // seize a non-existent loan
         uint nonExistentEscrowId = 999;
         expectRevertERC721Nonexistent(nonExistentEscrowId);
         escrowNFT.seizeEscrow(nonExistentEscrowId);

--- a/test/unit/Loans.escrow.reverts.t.sol
+++ b/test/unit/Loans.escrow.reverts.t.sol
@@ -22,14 +22,14 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
 
         // not enough approval for fee
         vm.startPrank(user1);
-        underlying.approve(address(loans), underlyingAmount + escrowFee - 1);
+        underlying.approve(address(loans), underlyingAmount + escrowFees - 1);
         expectRevertERC20Allowance(
-            address(loans), underlyingAmount + escrowFee - 1, underlyingAmount + escrowFee
+            address(loans), underlyingAmount + escrowFees - 1, underlyingAmount + escrowFees
         );
         openLoan(underlyingAmount, minLoanAmount, 0, 0);
 
         // fix allowance
-        underlying.approve(address(loans), underlyingAmount + escrowFee);
+        underlying.approve(address(loans), underlyingAmount + escrowFees);
 
         // unsupported escrow
         setCanOpenSingle(address(escrowNFT), false);
@@ -66,7 +66,7 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
 
         vm.startPrank(user1);
         prepareDefaultSwapToCash();
-        underlying.approve(address(loans), underlyingAmount + escrowFee);
+        underlying.approve(address(loans), underlyingAmount + escrowFees);
         vm.expectRevert("loans: duration mismatch");
         openLoan(underlyingAmount, minLoanAmount, 0, providerOffer);
 
@@ -80,152 +80,60 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
         openLoan(underlyingAmount, minLoanAmount, 0, providerOffer);
     }
 
-    function test_revert_closeLoan_checkLateFee() public {
-        (uint loanId,, uint loanAmount) = createAndCheckLoan();
-        skip(duration + maxGracePeriod);
-        updatePrice();
-        vm.startPrank(user1);
-        cashAsset.approve(address(loans), loanAmount);
-
-        // 0 out
-        prepareSwap(underlying, 0);
-        vm.expectRevert("loans: fromSwap < lateFee");
-        loans.closeLoan(loanId, defaultSwapParams(0));
-
-        // 1 wei less than late fee
-        (, uint lateFee) = escrowNFT.currentOwed(loans.getLoan(loanId).escrowId);
-        prepareSwap(underlying, lateFee - 1);
-        vm.expectRevert("loans: fromSwap < lateFee");
-        loans.closeLoan(loanId, defaultSwapParams(0));
-    }
-
-    function test_revert_unwrapAndCancelLoan_timing() public {
+    function test_revert_seizeEscrow_timingAndAuthorization() public {
         (uint loanId,,) = createAndCheckLoan();
-        // after expiry
-        skip(duration + 1);
-        // cannot unwrap
-        vm.expectRevert("loans: loan expired");
-        loans.unwrapAndCancelLoan(loanId);
-    }
+        ILoansNFT.Loan memory loan = loans.getLoan(loanId);
 
-    function test_revert_forecloseLoan_timingAndAuthorization() public {
-        (uint loanId,,) = createAndCheckLoan();
-
-        // view reverts too foreclosureValues
-        vm.expectRevert("loans: taker position not settled");
-        loans.foreclosureValues(loanId);
-
-        // foreclose before settlement
+        // seize before settlement
         vm.startPrank(supplier);
-        vm.expectRevert("loans: taker position not settled");
-        loans.forecloseLoan(loanId, defaultSwapParams(0));
+        vm.expectRevert("escrow: grace period not elapsed");
+        escrowNFT.seizeEscrow(loan.escrowId);
 
         // settle
         skip(duration);
         updatePrice();
         takerNFT.settlePairedPosition(loanId);
-        (uint gracePeriod,) = loans.foreclosureValues(loanId);
 
         // at the end of grace period
-        skip(gracePeriod);
-        updatePrice();
-        prepareDefaultSwapToUnderlying();
-        vm.expectRevert("loans: cannot foreclose yet");
-        loans.forecloseLoan(loanId, defaultSwapParams(0));
+        skip(escrowNFT.MIN_GRACE_PERIOD());
+        vm.expectRevert("escrow: grace period not elapsed");
+        escrowNFT.seizeEscrow(loan.escrowId);
 
-        // foreclose from an unauthorized address
+        // seize from an unauthorized address
         vm.startPrank(user1);
-        vm.expectRevert("loans: not escrow owner or allowed keeper");
-        loans.forecloseLoan(loanId, defaultSwapParams(0));
+        vm.expectRevert("escrow: not escrow owner");
+        escrowNFT.seizeEscrow(loan.escrowId);
 
-        // set the keeper
-        vm.startPrank(owner);
-        loans.setKeeper(keeper);
-
-        // keeper not authorized by supplier
-        vm.startPrank(keeper);
-        vm.expectRevert("loans: not escrow owner or allowed keeper");
-        loans.forecloseLoan(loanId, defaultSwapParams(0));
-
-        // keeper authorized by user but not supplier
-        vm.startPrank(user1);
-        loans.setKeeperApproved(loanId, true);
-        vm.startPrank(keeper);
-        vm.expectRevert("loans: not escrow owner or allowed keeper");
-        loans.forecloseLoan(loanId, defaultSwapParams(0));
-
-        // allow keeper
-        vm.startPrank(supplier);
-        loans.setKeeperApproved(loanId, true);
-
-        // foreclosable now
+        // seize now
         skip(1);
-        updatePrice();
-        prepareDefaultSwapToUnderlying();
 
         // Keeper can now foreclose
-        vm.startPrank(keeper);
-        loans.forecloseLoan(loanId, defaultSwapParams(0));
+        vm.startPrank(supplier);
+        escrowNFT.seizeEscrow(loan.escrowId);
     }
 
-    function test_revert_forecloseLoan_invalidLoanStates() public {
+    function test_revert_seizeEscrow_invalidLoanStates() public {
         // foreclose a non-existent loan
-        uint nonExistentLoanId = 999;
-        expectRevertERC721Nonexistent(nonExistentLoanId);
-        loans.forecloseLoan(nonExistentLoanId, defaultSwapParams(0));
+        uint nonExistentEscrowId = 999;
+        expectRevertERC721Nonexistent(nonExistentEscrowId);
+        escrowNFT.seizeEscrow(nonExistentEscrowId);
 
         // create and cancel a loan
-        (uint loanId,,) = createAndCheckLoan();
+        (uint loanId,, uint loanAmount) = createAndCheckLoan();
+
+        uint checkpoint = vm.snapshotState();
         vm.startPrank(user1);
         loans.unwrapAndCancelLoan(loanId);
         vm.startPrank(supplier);
-        expectRevertERC721Nonexistent(loanId);
-        loans.forecloseLoan(loanId, defaultSwapParams(0));
+        vm.expectRevert("escrow: already released");
+        escrowNFT.seizeEscrow(loans.getLoan(loanId).escrowId);
 
-        // create a non-escrow loan
-        openEscrowLoan = false;
-        (uint nonEscrowLoanId,,) = createAndCheckLoan();
+        vm.revertTo(checkpoint);
+        vm.startPrank(user1);
+        cashAsset.approve(address(loans), loanAmount);
+        loans.closeLoan(loanId, defaultSwapParams(0));
         vm.startPrank(supplier);
-        vm.expectRevert("loans: not an escrowed loan");
-        loans.forecloseLoan(nonEscrowLoanId, defaultSwapParams(0));
-    }
-
-    function test_revert_forecloseLoan_invalidParameters() public {
-        (uint loanId,,) = createAndCheckLoan();
-
-        // after grace period
-        skip(duration + maxGracePeriod + 1);
-        updatePrice();
-        takerNFT.settlePairedPosition(loanId);
-        uint swapOut = prepareDefaultSwapToUnderlying();
-
-        // foreclose with an invalid swapper
-        vm.startPrank(supplier);
-        vm.expectRevert("loans: swapper not allowed");
-        loans.forecloseLoan(loanId, ILoansNFT.SwapParams(0, address(0x123), ""));
-
-        // slippage
-        vm.expectRevert("SwapperUniV3: slippage exceeded");
-        loans.forecloseLoan(loanId, ILoansNFT.SwapParams(swapOut + 1, defaultSwapper, ""));
-    }
-
-    function test_revert_forecloseLoan_invalidParameters_zeroAmountSwap() public {
-        (uint loanId,,) = createAndCheckLoan();
-
-        // after grace period
-        skip(duration + maxGracePeriod + 1);
-        updatePrice(1); // set low price to cause 0 amount swap
-        takerNFT.settlePairedPosition(loanId);
-        // check no cash
-        assertEq(takerNFT.getPosition(loanId).withdrawable, 0);
-
-        // foreclose with an invalid swapper
-        vm.startPrank(supplier);
-        vm.expectRevert("loans: swapper not allowed");
-        loans.forecloseLoan(loanId, ILoansNFT.SwapParams(0, address(0x123), ""));
-
-        // slippage
-        vm.expectRevert("loans: slippage exceeded");
-        loans.forecloseLoan(loanId, ILoansNFT.SwapParams(1, defaultSwapper, ""));
+        vm.expectRevert("escrow: already released");
+        escrowNFT.seizeEscrow(loans.getLoan(loanId).escrowId);
     }
 }

--- a/test/unit/Loans.rolls.effects.t.sol
+++ b/test/unit/Loans.rolls.effects.t.sol
@@ -87,7 +87,7 @@ contract LoansRollTestBase is LoansTestBase {
         // Execute roll
         vm.startPrank(user1);
         cashAsset.approve(address(loans), type(uint).max);
-        underlying.approve(address(loans), escrowFee);
+        underlying.approve(address(loans), escrowFees);
 
         uint userCash = cashAsset.balanceOf(user1);
         uint userUnderlying = underlying.balanceOf(user1);
@@ -108,19 +108,19 @@ contract LoansRollTestBase is LoansTestBase {
         uint newLoanAmount;
         int toUser;
         (newLoanId, newLoanAmount, toUser) =
-            loans.rollLoan(loanId, rollOffer(rollId), minToUser, escrowOfferId, escrowFee);
+            loans.rollLoan(loanId, rollOffer(rollId), minToUser, escrowOfferId, escrowFees);
         if (expected.isEscrowLoan) {
             // sanity checks for test values
             assertGt(escrowOfferId, 0);
-            assertGt(escrowFee, 0);
+            assertGt(escrowFees, 0);
             // check new escrow
-            _checkEscrowViews(newLoanId, expected.newEscrowId, escrowFee);
+            _checkEscrowViews(newLoanId, expected.newEscrowId, escrowFees);
             // old released
             assertTrue(escrowNFT.getEscrow(prevLoan.escrowId).released);
         } else {
             // sanity checks for test values
             assertEq(escrowOfferId, 0);
-            assertEq(escrowFee, 0);
+            assertEq(escrowFees, 0);
         }
 
         // id
@@ -133,7 +133,7 @@ contract LoansRollTestBase is LoansTestBase {
 
         // balance change matches roll output value
         assertEq(cashAsset.balanceOf(user1), uint(int(userCash) + expected.toTaker));
-        assertEq(underlying.balanceOf(user1), userUnderlying + expected.escrowFeeRefund - escrowFee);
+        assertEq(underlying.balanceOf(user1), userUnderlying + expected.escrowFeeRefund - escrowFees);
         // loan change matches balance change
         int loanChange = int(newLoanAmount) - int(prevLoan.loanAmount);
         assertEq(expected.toTaker, toUser);
@@ -303,7 +303,7 @@ contract LoansRollsEscrowEffectsTest is LoansRollsEffectsTest {
 
     function test_rollLoan_escrowRefund() public {
         (uint loanId,,) = createAndCheckLoan();
-        uint prevFee = escrowFee;
+        uint prevFee = escrowFees;
         (, ExpectedRoll memory expected) = checkRollLoan(loanId, oraclePrice);
         // max refund
         uint maxRefund = escrowNFT.MAX_FEE_REFUND_BIPS() * prevFee / BIPS_100PCT;
@@ -311,14 +311,14 @@ contract LoansRollsEscrowEffectsTest is LoansRollsEffectsTest {
 
         (loanId,,) = createAndCheckLoan();
         skip(duration / 2);
-        prevFee = escrowFee;
+        prevFee = escrowFees;
         (, expected) = checkRollLoan(loanId, oraclePrice);
         // half refund for half duration
         assertEq(expected.escrowFeeRefund, prevFee / 2);
 
         (loanId,,) = createAndCheckLoan();
         skip(duration);
-        prevFee = escrowFee;
+        prevFee = escrowFees;
         (, expected) = checkRollLoan(loanId, oraclePrice);
         // no refund for full duraion
         assertEq(expected.escrowFeeRefund, 0);

--- a/test/unit/Loans.rolls.effects.t.sol
+++ b/test/unit/Loans.rolls.effects.t.sol
@@ -303,24 +303,25 @@ contract LoansRollsEscrowEffectsTest is LoansRollsEffectsTest {
 
     function test_rollLoan_escrowRefund() public {
         (uint loanId,,) = createAndCheckLoan();
+        (, uint interestHeld, uint lateFeeHeld) = escrowNFT.upfrontFees(escrowOfferId, underlyingAmount);
         uint prevFee = escrowFees;
         (, ExpectedRoll memory expected) = checkRollLoan(loanId, oraclePrice);
         // max refund
-        uint maxRefund = escrowNFT.MAX_FEE_REFUND_BIPS() * prevFee / BIPS_100PCT;
-        assertEq(expected.escrowFeeRefund, maxRefund);
+        uint maxInterestRefund = escrowNFT.MAX_FEE_REFUND_BIPS() * interestHeld / BIPS_100PCT;
+        assertEq(expected.escrowFeeRefund, maxInterestRefund + lateFeeHeld);
 
         (loanId,,) = createAndCheckLoan();
         skip(duration / 2);
         prevFee = escrowFees;
         (, expected) = checkRollLoan(loanId, oraclePrice);
         // half refund for half duration
-        assertEq(expected.escrowFeeRefund, prevFee / 2);
+        assertEq(expected.escrowFeeRefund, interestHeld / 2 + lateFeeHeld);
 
         (loanId,,) = createAndCheckLoan();
         skip(duration);
         prevFee = escrowFees;
         (, expected) = checkRollLoan(loanId, oraclePrice);
-        // no refund for full duraion
-        assertEq(expected.escrowFeeRefund, 0);
+        // only late fee refund for full duration
+        assertEq(expected.escrowFeeRefund, lateFeeHeld);
     }
 }

--- a/test/unit/Loans.rolls.reverts.t.sol
+++ b/test/unit/Loans.rolls.reverts.t.sol
@@ -65,8 +65,8 @@ contract LoansRollsRevertsTest is LoansRollTestBase {
         (uint newLoanId,,) = createAndCheckLoan();
         uint newRollId = createRollOffer(newLoanId);
         vm.startPrank(user1);
-        underlying.approve(address(loans), escrowFee);
-        loans.rollLoan(newLoanId, rollOffer(newRollId), MIN_INT, escrowOfferId, escrowFee);
+        underlying.approve(address(loans), escrowFees);
+        loans.rollLoan(newLoanId, rollOffer(newRollId), MIN_INT, escrowOfferId, escrowFees);
         // token is burned
         expectRevertERC721Nonexistent(newLoanId);
         loans.rollLoan(newLoanId, rollOffer(newRollId), MIN_INT, 0, 0);
@@ -80,7 +80,7 @@ contract LoansRollsRevertsTest is LoansRollTestBase {
         uint rollId = createRollOffer(loanId);
 
         vm.startPrank(user1);
-        underlying.approve(address(loans), escrowFee);
+        underlying.approve(address(loans), escrowFees);
         vm.mockCall(
             address(rolls),
             abi.encodeWithSelector(rolls.executeRoll.selector, rollId, 0),
@@ -243,17 +243,17 @@ contract LoansRollsEscrowRevertsTest is LoansRollsRevertsTest {
 
         // not enough approval for fee
         vm.startPrank(user1);
-        cashAsset.approve(address(loans), escrowFee - 1);
+        cashAsset.approve(address(loans), escrowFees - 1);
         cashAsset.approve(address(loans), type(uint).max);
-        underlying.approve(address(loans), escrowFee - 1);
-        expectRevertERC20Allowance(address(loans), escrowFee - 1, escrowFee);
-        loans.rollLoan(loanId, rollOffer(rollId), MIN_INT, escrowOfferId, escrowFee);
+        underlying.approve(address(loans), escrowFees - 1);
+        expectRevertERC20Allowance(address(loans), escrowFees - 1, escrowFees);
+        loans.rollLoan(loanId, rollOffer(rollId), MIN_INT, escrowOfferId, escrowFees);
 
         // unsupported escrow
         setCanOpenSingle(address(escrowNFT), false);
         vm.startPrank(user1);
         vm.expectRevert("loans: unsupported escrow");
-        loans.rollLoan(loanId, rollOffer(rollId), MIN_INT, escrowOfferId, escrowFee);
+        loans.rollLoan(loanId, rollOffer(rollId), MIN_INT, escrowOfferId, escrowFees);
     }
 
     function test_revert_rollLoan_escrowValidations() public {
@@ -270,9 +270,9 @@ contract LoansRollsEscrowRevertsTest is LoansRollsRevertsTest {
         vm.startPrank(user1);
         prepareDefaultSwapToCash();
         cashAsset.approve(address(loans), type(uint).max);
-        underlying.approve(address(loans), underlyingAmount + escrowFee);
+        underlying.approve(address(loans), underlyingAmount + escrowFees);
         vm.expectRevert("loans: duration mismatch");
-        loans.rollLoan(loanId, rollOffer(rollId), MIN_INT, escrowOfferId, escrowFee);
+        loans.rollLoan(loanId, rollOffer(rollId), MIN_INT, escrowOfferId, escrowFees);
 
         // loanId mismatch escrow
         IEscrowSupplierNFT.Escrow memory badEscrow;
@@ -283,7 +283,7 @@ contract LoansRollsEscrowRevertsTest is LoansRollsRevertsTest {
             abi.encode(badEscrow)
         );
         vm.expectRevert("loans: unexpected loanId");
-        loans.rollLoan(loanId, rollOffer(rollId), MIN_INT, escrowOfferId, escrowFee);
+        loans.rollLoan(loanId, rollOffer(rollId), MIN_INT, escrowOfferId, escrowFees);
     }
 }
 


### PR DESCRIPTION
Upfront hold late fees payment, and refund on release. Important differences in flows:
- Late fees are held upfront (together with interest fees).
- They are refunded when escrow is released (in either close or cancel), but not refunded after grace period end (if seized or closed).
- Loans is expected to only return the principal on closing.
- Escrow loans are cancellable at any time, if escrow is seized, it will not try to release it.
- Grace period is fixed now (by the offer), during it, escrow cannot be seized, and late fees are refunded pro-rata.
- Min grace period is still enforced and during it late fees are 0.
- Any initial overpayment of fees is refunded in the end (unless seized).
- An added view for all three refunds: interest, late fees, and overpayment (initial overage of fees sent in).
- Switch escrow still expects the full new fees to be pulled regardless of the larger refund. It pulls the full fee, and refund the previous fee. This is suboptimal UX, but simpler.

There are significant simplifications due to removal of foreclosure and its complexity:
- Gone: capped grace period calc, foreclose swap, foreclose refund transfer, oracle conversions, closing late fee underpayment fix, 0 amount swap fix, late fee only repayment and it's internal flag, keeper usage for foreclosure
- Reduced ops - no need to for keeper to deal with foreclosures 
- Better UX for end of escrow: simpler flow, less methods, no timing issues