### PR TITLE
Tests improvements

### DIFF
--- a/test/integration/arbitrum-mainnet/BaseForkTest.sol
+++ b/test/integration/arbitrum-mainnet/BaseForkTest.sol
@@ -118,9 +118,12 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
 
     uint expectedOraclePrice;
 
+    uint expectedNumPairs;
+
     // values to be set by pair
     address cashAsset;
     address underlying;
+    uint expectedPairIndex;
     uint offerAmount;
     uint underlyingAmount;
     uint minLoanAmount;

--- a/test/integration/arbitrum-mainnet/BaseForkTest.sol
+++ b/test/integration/arbitrum-mainnet/BaseForkTest.sol
@@ -147,7 +147,6 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
     uint slippage;
     uint callstrikeToUse;
     uint duration;
-    uint durationPriceMovement;
     uint ltv;
 
     BaseDeployer.AssetPairContracts internal pair;
@@ -303,9 +302,10 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         checkLoanAmount(loanAmount);
         skip(duration);
         ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
-        (uint takerWithdrawal,) = pair.takerNFT.previewSettlement(position, pair.oracle.currentPrice());
+        uint currentPrice = pair.oracle.currentPrice();
+        (uint takerWithdrawal,) = pair.takerNFT.previewSettlement(position, currentPrice);
 
-        closeAndCheckLoan(loanId, loanAmount, loanAmount + takerWithdrawal, 0);
+        closeAndCheckLoan(loanId, loanAmount, loanAmount + takerWithdrawal, 0, currentPrice);
     }
 
     function testOpenEscrowLoan() public {
@@ -337,9 +337,10 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         skip(duration);
 
         ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
-        (uint takerWithdrawal,) = pair.takerNFT.previewSettlement(position, pair.oracle.currentPrice());
+        uint currentPrice = pair.oracle.currentPrice();
+        (uint takerWithdrawal,) = pair.takerNFT.previewSettlement(position, currentPrice);
 
-        closeAndCheckLoan(loanId, loanAmount, loanAmount + takerWithdrawal, 0);
+        closeAndCheckLoan(loanId, loanAmount, loanAmount + takerWithdrawal, 0, currentPrice);
 
         // Check escrow position's withdrawable amount (underlying + interest)
         uint withdrawable = pair.escrowNFT.getEscrow(loanBefore.escrowId).withdrawable;
@@ -433,10 +434,13 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         // Track second supplier balance before closing
         uint escrowSupplier2Before = pair.underlying.balanceOf(escrowSupplier2);
 
-        (uint takerWithdrawal,) =
-            pair.takerNFT.previewSettlement(pair.takerNFT.getPosition(newLoanId), pair.oracle.currentPrice());
+        {
+            uint currentPrice = pair.oracle.currentPrice();
+            (uint takerWithdrawal,) =
+                pair.takerNFT.previewSettlement(pair.takerNFT.getPosition(newLoanId), currentPrice);
 
-        closeAndCheckLoan(newLoanId, newLoanAmount, newLoanAmount + takerWithdrawal, 0);
+            closeAndCheckLoan(newLoanId, newLoanAmount, newLoanAmount + takerWithdrawal, 0, currentPrice);
+        }
 
         // Execute withdrawal for second supplier
         vm.startPrank(escrowSupplier2);
@@ -521,9 +525,10 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         skip(duration);
 
         ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(newLoanId);
-        (uint takerWithdrawal,) = pair.takerNFT.previewSettlement(position, pair.oracle.currentPrice());
+        uint currentPrice = pair.oracle.currentPrice();
+        (uint takerWithdrawal,) = pair.takerNFT.previewSettlement(position, currentPrice);
 
-        closeAndCheckLoan(newLoanId, newLoanAmount, newLoanAmount + takerWithdrawal, 0);
+        closeAndCheckLoan(newLoanId, newLoanAmount, newLoanAmount + takerWithdrawal, 0, currentPrice);
         assertGt(initialLoanAmount, 0);
         assertGe(int(newLoanAmount), int(initialLoanAmount) + transferAmount);
 
@@ -542,12 +547,16 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         assertGt(protocolFee, 0);
     }
 
-    function closeAndCheckLoan(uint loanId, uint loanAmount, uint totalAmountToSwap, uint lateFee) internal {
+    function closeAndCheckLoan(
+        uint loanId,
+        uint loanAmount,
+        uint totalAmountToSwap,
+        uint lateFee,
+        uint currentPrice
+    ) internal {
         // Track balances before closing
         uint userCashBefore = pair.cashAsset.balanceOf(user);
         uint userUnderlyingBefore = pair.underlying.balanceOf(user);
-        // Get current price from oracle
-        uint currentPrice = pair.oracle.currentPrice();
         // Convert cash amount to expected underlying amount using oracle's conversion
         uint expectedUnderlying = pair.oracle.convertToBaseAmount(totalAmountToSwap, currentPrice) - lateFee;
 
@@ -560,232 +569,88 @@ abstract contract BaseLoansForkTest is LoansForkTestBase {
         assertEq(pair.underlying.balanceOf(user) - userUnderlyingBefore, underlyingOut);
     }
 
-    // commented out because skipping to after grace period makes price go stale
-    //
-    //    function testCloseEscrowLoanAfterGracePeriod() public {
-    //        //  create provider and escrow offers
-    //        (uint offerId, uint escrowOfferId) = createEscrowOffers();
-    //        (uint loanId,, uint loanAmount) = executeEscrowLoan(offerId, escrowOfferId);
-    //
-    //        ILoansNFT.Loan memory loanBefore = pair.loansContract.getLoan(loanId);
-    //        uint escrowSupplierBefore = pair.underlying.balanceOf(escrowSupplier);
-    //        uint interestFee = pair.escrowNFT.interestFee(escrowOfferId, underlyingAmount);
-    //
-    //        // Skip past expiry
-    //        skip(duration);
-    //        uint expiryPrice = pair.oracle.currentPrice();
-    //        // Get expiry price from oracle
-    //        ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
-    //        (uint takerWithdrawal,) = pair.takerNFT.previewSettlement(position, expiryPrice);
-    //        // bot settles the position
-    //        pair.takerNFT.settlePairedPosition(loanId);
-    //
-    //        // skip past grace period
-    //        skip(maxGracePeriod + 1);
-    //
-    //        // Calculate expected late fee
-    //        (, uint lateFee) = pair.escrowNFT.currentOwed(loanBefore.escrowId);
-    //        assertGt(lateFee, 0);
-    //
-    //        uint totalAmountToSwap = loanAmount + takerWithdrawal;
-    //        closeAndCheckLoan(loanId, loanAmount, totalAmountToSwap, lateFee);
-    //
-    //        // Check escrow position's withdrawable (underlying + interest + late fee)
-    //        uint withdrawable = pair.escrowNFT.getEscrow(loanBefore.escrowId).withdrawable;
-    //        assertEq(withdrawable, underlyingAmount + interestFee + lateFee);
-    //
-    //        // Execute withdrawal and verify balance
-    //        vm.startPrank(escrowSupplier);
-    //        pair.escrowNFT.withdrawReleased(loanBefore.escrowId);
-    //        vm.stopPrank();
-    //
-    //        assertEq(
-    //            pair.underlying.balanceOf(escrowSupplier) - escrowSupplierBefore,
-    //            underlyingAmount + interestFee + lateFee
-    //        );
-    //    }
+    function testCloseEscrowLoanAfterGracePeriod() public {
+        //  create provider and escrow offers
+        (uint offerId, uint escrowOfferId) = createEscrowOffers();
+        (uint loanId,, uint loanAmount) = executeEscrowLoan(offerId, escrowOfferId);
 
-    // commented out because skipping to after min grace period makes price go stale
-    //
-    //    function testCloseEscrowLoanWithPartialLateFees() public {
-    //        //  create provider and escrow offers
-    //        (uint offerId, uint escrowOfferId) = createEscrowOffers();
-    //        (uint loanId,, uint loanAmount) = executeEscrowLoan(offerId, escrowOfferId);
-    //
-    //        ILoansNFT.Loan memory loanBefore = pair.loansContract.getLoan(loanId);
-    //        uint escrowSupplierBefore = pair.underlying.balanceOf(escrowSupplier);
-    //        uint interestFee = pair.escrowNFT.interestFee(escrowOfferId, underlyingAmount);
-    //
-    //        // Skip past expiry but only halfway through grace period
-    //        skip(duration + maxGracePeriod / 2);
-    //
-    //        // Calculate expected partial late fee
-    //        (, uint lateFee) = pair.escrowNFT.currentOwed(loanBefore.escrowId);
-    //        assertGt(lateFee, 0);
-    //        assertLt(lateFee, underlyingAmount * lateFeeAPR * maxGracePeriod / (BIPS_BASE * 365 days));
-    //        ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
-    //        (uint takerWithdrawal,) = pair.takerNFT.previewSettlement(position, pair.oracle.currentPrice());
-    //
-    //        closeAndCheckLoan(loanId, loanAmount, loanAmount + takerWithdrawal, lateFee);
-    //
-    //        // Check escrow position's withdrawable (underlying + interest + partial late fee)
-    //        uint withdrawable = pair.escrowNFT.getEscrow(loanBefore.escrowId).withdrawable;
-    //        assertEq(withdrawable, underlyingAmount + interestFee + lateFee);
-    //
-    //        // Execute withdrawal and verify balance
-    //        vm.startPrank(escrowSupplier);
-    //        pair.escrowNFT.withdrawReleased(loanBefore.escrowId);
-    //        vm.stopPrank();
-    //
-    //        assertEq(
-    //            pair.underlying.balanceOf(escrowSupplier) - escrowSupplierBefore,
-    //            underlyingAmount + interestFee + lateFee
-    //        );
-    //    }
+        ILoansNFT.Loan memory loanBefore = pair.loansContract.getLoan(loanId);
+        uint escrowSupplierBefore = pair.underlying.balanceOf(escrowSupplier);
+        uint interestFee = pair.escrowNFT.interestFee(escrowOfferId, underlyingAmount);
 
-    // price movement settlement tests
+        // Skip past expiry
+        skip(duration);
+        uint expiryPrice = pair.oracle.currentPrice();
+        // Get expiry price from oracle
+        ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
+        (uint takerWithdrawal,) = pair.takerNFT.previewSettlement(position, expiryPrice);
+        // bot settles the position
+        pair.takerNFT.settlePairedPosition(loanId);
 
-    //    function testSettlementPriceAboveCallStrike() public {
-    //        // Create provider offer & open loan
-    //        uint offerId = createProviderOffer(pair, callstrikeToUse, offerAmount, durationPriceMovement, ltv);
-    //        (uint loanId,, uint loanAmount) = openLoan(pair, user, underlyingAmount, minLoanAmount, offerId);
-    //
-    //        ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
-    //
-    //        // a bit over call strike due to time effects on TWAP
-    //        uint priceTarget = (pair.oracle.currentPrice() * (position.callStrikePercent + 100) / BIPS_BASE);
-    //
-    //        skip(durationPriceMovement / 2);
-    //
-    //        // Move price above call strike using lib
-    //        PriceMovementHelper.moveToTargetPrice(
-    //            vm,
-    //            address(pair.swapperUniV3.uniV3SwapRouter()),
-    //            whale,
-    //            pair.cashAsset,
-    //            pair.underlying,
-    //            pair.oracle,
-    //            priceTarget,
-    //            swapStepCashAmount,
-    //            swapPoolFeeTier
-    //        );
-    //
-    //        // moving price takes time, but we need settlement price to be moved
-    //        skip(durationPriceMovement / 2);
-    //
-    //        (uint expectedTakerWithdrawal,) =
-    //            pair.takerNFT.previewSettlement(position, pair.oracle.currentPrice());
-    //
-    //        // Total cash = taker withdrawal + loan repayment
-    //        // Convert expected total cash to underlying at current price
-    //        uint expectedUnderlyingOut =
-    //            pair.oracle.convertToBaseAmount(expectedTakerWithdrawal + loanAmount, pair.oracle.currentPrice());
-    //
-    //        uint userUnderlyingBefore = pair.underlying.balanceOf(user);
-    //
-    //        // Close loan and settle
-    //        closeAndCheckLoan(loanId, loanAmount, loanAmount + expectedTakerWithdrawal, 0);
-    //
-    //        // Check provider's withdrawable amount
-    //        uint providerWithdrawable = position.providerNFT.getPosition(position.providerId).withdrawable;
-    //        assertEq(providerWithdrawable, 0); // everything to user
-    //
-    //        // Check user's underlying balance change against calculated expected amount
-    //        assertApproxEqAbs(
-    //            pair.underlying.balanceOf(user) - userUnderlyingBefore,
-    //            expectedUnderlyingOut,
-    //            expectedUnderlyingOut * slippage / BIPS_BASE // within slippage% of expected
-    //        );
-    //    }
+        // skip past grace period
+        skip(maxGracePeriod + 1);
 
-    //    function testSettlementPriceBelowPutStrike() public {
-    //        // Create provider offer & open loan
-    //        uint offerId = createProviderOffer(pair, callstrikeToUse, offerAmount, durationPriceMovement, ltv);
-    //        (uint loanId,, uint loanAmount) = openLoan(pair, user, underlyingAmount, minLoanAmount, offerId);
-    //
-    //        ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
-    //
-    //        skip(durationPriceMovement / 2);
-    //
-    //        // Move price below put strike
-    //        PriceMovementHelper.moveToTargetPrice(
-    //            vm,
-    //            address(pair.swapperUniV3.uniV3SwapRouter()),
-    //            whale,
-    //            pair.cashAsset,
-    //            pair.underlying,
-    //            pair.oracle,
-    //            (pair.oracle.currentPrice() * position.putStrikePercent / BIPS_BASE),
-    //            swapStepCashAmount,
-    //            swapPoolFeeTier
-    //        );
-    //
-    //        // moving price takes time, but we need settlement price to be moved
-    //        skip(durationPriceMovement / 2);
-    //
-    //        uint userUnderlyingBefore = pair.underlying.balanceOf(user);
-    //        // Close loan
-    //        closeAndCheckLoan(loanId, loanAmount, loanAmount, 0);
-    //        uint expectedUnderlying = pair.oracle.convertToBaseAmount(loanAmount, pair.oracle.currentPrice());
-    //        assertApproxEqAbs(
-    //            pair.underlying.balanceOf(user) - userUnderlyingBefore,
-    //            expectedUnderlying,
-    //            expectedUnderlying * slippage / BIPS_BASE
-    //        );
-    //        // check provider gets all value
-    //        uint providerWithdrawable = position.providerNFT.getPosition(position.providerId).withdrawable;
-    //        uint expectedProviderWithdrawable = position.providerLocked + position.takerLocked;
-    //        assertEq(providerWithdrawable, expectedProviderWithdrawable);
-    //    }
+        // Calculate expected late fee
+        (, uint lateFee) = pair.escrowNFT.currentOwed(loanBefore.escrowId);
+        assertGt(lateFee, 0);
 
-    //    function testSettlementPriceUpBetweenStrikes() public {
-    //        // Create provider offer & open loan with longer duration
-    //        uint offerId = createProviderOffer(pair, callstrikeToUse, offerAmount, durationPriceMovement, ltv);
-    //        (uint loanId,, uint loanAmount) = openLoan(pair, user, underlyingAmount, minLoanAmount, offerId);
-    //
-    //        ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
-    //
-    //        skip(durationPriceMovement / 2);
-    //
-    //        // Move price half way to call strike using lib
-    //        uint halfDeviation = (BIPS_BASE + position.callStrikePercent) / 2;
-    //        PriceMovementHelper.moveToTargetPrice(
-    //            vm,
-    //            address(pair.swapperUniV3.uniV3SwapRouter()),
-    //            whale,
-    //            pair.cashAsset,
-    //            pair.underlying,
-    //            pair.oracle,
-    //            (pair.oracle.currentPrice() * halfDeviation / BIPS_BASE),
-    //            swapStepCashAmount,
-    //            swapPoolFeeTier
-    //        );
-    //
-    //        // moving price takes time, but we need settlement price to be moved
-    //        skip(durationPriceMovement / 2);
-    //
-    //        // Calculate expected settlement amounts
-    //        uint currentPrice = pair.oracle.currentPrice();
-    //        (uint expectedTakerWithdrawal, int expectedProviderDelta) =
-    //            pair.takerNFT.previewSettlement(position, currentPrice);
-    //
-    //        uint userUnderlyingBefore = pair.underlying.balanceOf(user);
-    //
-    //        // Close loan with total cash needed
-    //        closeAndCheckLoan(loanId, loanAmount, loanAmount + expectedTakerWithdrawal, 0);
-    //
-    //        // User should get underlying equivalent to loanAmount + their settlement gains
-    //        uint expectedUnderlying =
-    //            pair.oracle.convertToBaseAmount(loanAmount + expectedTakerWithdrawal, currentPrice);
-    //        assertApproxEqAbs(
-    //            pair.underlying.balanceOf(user) - userUnderlyingBefore,
-    //            expectedUnderlying,
-    //            expectedUnderlying * slippage / BIPS_BASE
-    //        );
-    //
-    //        // Provider should get their locked amount adjusted by settlement delta
-    //        uint providerWithdrawable = position.providerNFT.getPosition(position.providerId).withdrawable;
-    //        uint expectedProviderWithdrawable = uint(int(position.providerLocked) + expectedProviderDelta);
-    //        assertEq(providerWithdrawable, expectedProviderWithdrawable);
-    //    }
+        uint totalAmountToSwap = loanAmount + takerWithdrawal;
+        closeAndCheckLoan(loanId, loanAmount, totalAmountToSwap, lateFee, expiryPrice);
+
+        // Check escrow position's withdrawable (underlying + interest + late fee)
+        uint withdrawable = pair.escrowNFT.getEscrow(loanBefore.escrowId).withdrawable;
+        assertEq(withdrawable, underlyingAmount + interestFee + lateFee);
+
+        // Execute withdrawal and verify balance
+        vm.startPrank(escrowSupplier);
+        pair.escrowNFT.withdrawReleased(loanBefore.escrowId);
+        vm.stopPrank();
+
+        assertEq(
+            pair.underlying.balanceOf(escrowSupplier) - escrowSupplierBefore,
+            underlyingAmount + interestFee + lateFee
+        );
+    }
+
+    function testCloseEscrowLoanWithPartialLateFees() public {
+        //  create provider and escrow offers
+        (uint offerId, uint escrowOfferId) = createEscrowOffers();
+        (uint loanId,, uint loanAmount) = executeEscrowLoan(offerId, escrowOfferId);
+
+        ILoansNFT.Loan memory loanBefore = pair.loansContract.getLoan(loanId);
+        uint escrowSupplierBefore = pair.underlying.balanceOf(escrowSupplier);
+        uint interestFee = pair.escrowNFT.interestFee(escrowOfferId, underlyingAmount);
+
+        // Skip past expiry but only halfway through grace period
+        skip(duration);
+        uint expiryPrice = pair.oracle.currentPrice();
+
+        // bot settles the position
+        pair.takerNFT.settlePairedPosition(loanId);
+
+        skip(maxGracePeriod / 2);
+
+        // Calculate expected partial late fee
+        (, uint lateFee) = pair.escrowNFT.currentOwed(loanBefore.escrowId);
+        assertGt(lateFee, 0);
+        assertLt(lateFee, underlyingAmount * lateFeeAPR * maxGracePeriod / (BIPS_BASE * 365 days));
+        ICollarTakerNFT.TakerPosition memory position = pair.takerNFT.getPosition(loanId);
+        uint takerWithdrawal = position.withdrawable;
+
+        closeAndCheckLoan(loanId, loanAmount, loanAmount + takerWithdrawal, lateFee, expiryPrice);
+
+        // Check escrow position's withdrawable (underlying + interest + partial late fee)
+        uint withdrawable = pair.escrowNFT.getEscrow(loanBefore.escrowId).withdrawable;
+        assertEq(withdrawable, underlyingAmount + interestFee + lateFee);
+
+        // Execute withdrawal and verify balance
+        vm.startPrank(escrowSupplier);
+        pair.escrowNFT.withdrawReleased(loanBefore.escrowId);
+        vm.stopPrank();
+
+        assertEq(
+            pair.underlying.balanceOf(escrowSupplier) - escrowSupplierBefore,
+            underlyingAmount + interestFee + lateFee
+        );
+    }
 }

--- a/test/integration/arbitrum-mainnet/DeploymentLoader.sol
+++ b/test/integration/arbitrum-mainnet/DeploymentLoader.sol
@@ -82,15 +82,16 @@ abstract contract DeploymentLoader is Test, ArbitrumMainnetDeployer {
     function getPairByAssets(address cashAsset, address underlying)
         internal
         view
-        returns (BaseDeployer.AssetPairContracts memory pair)
+        returns (BaseDeployer.AssetPairContracts memory pair, uint i)
     {
-        for (uint i = 0; i < deployedPairs.length; i++) {
+        for (i = 0; i < deployedPairs.length; i++) {
             if (
                 address(deployedPairs[i].cashAsset) == cashAsset
                     && address(deployedPairs[i].underlying) == underlying
             ) {
-                return deployedPairs[i];
+                return (deployedPairs[i], i);
             }
         }
+        revert("not found");
     }
 }

--- a/test/integration/arbitrum-mainnet/Loans.fork.t.sol
+++ b/test/integration/arbitrum-mainnet/Loans.fork.t.sol
@@ -25,7 +25,6 @@ contract WETHUSDCLoansForkTest is BaseLoansForkTest {
         fundWallets();
 
         duration = 5 minutes;
-        durationPriceMovement = 30 days;
         ltv = 9000;
     }
 
@@ -44,9 +43,6 @@ contract WETHUSDCLoansForkTest is BaseLoansForkTest {
 
         slippage = 100; // 1%
         callstrikeToUse = 11_000;
-
-        // price movement swap amounts
-        swapStepCashAmount = 2_000_000e6;
 
         expectedOraclePrice = 3_000_000_000;
     }
@@ -70,7 +66,6 @@ contract WBTCUSDTLoansForkTest is WETHUSDCLoansForkTest {
         bigUnderlyingAmount = 100e8;
 
         callstrikeToUse = 10_500;
-        swapStepCashAmount = 500_000e6;
 
         expectedOraclePrice = 90_000_000_000;
     }

--- a/test/integration/arbitrum-mainnet/Loans.fork.t.sol
+++ b/test/integration/arbitrum-mainnet/Loans.fork.t.sol
@@ -11,8 +11,12 @@ contract WETHUSDCLoansForkTest is BaseLoansForkTest {
 
         _setParams();
 
-        pair = getPairByAssets(address(cashAsset), address(underlying));
+        uint pairIndex;
+        (pair, pairIndex) = getPairByAssets(address(cashAsset), address(underlying));
         require(address(pair.loansContract) != address(0), "Loans contract not deployed");
+        // ensure we're testing all deployed pairs
+        require(pairIndex == expectedPairIndex, "pair index mismatch");
+        require(deployedPairs.length == expectedNumPairs, "number of pairs mismatch");
 
         // Fund whale for price manipulation
         deal(address(pair.cashAsset), whale, 100 * bigCashAmount);
@@ -29,7 +33,11 @@ contract WETHUSDCLoansForkTest is BaseLoansForkTest {
     }
 
     function _setParams() internal virtual {
+        // @dev all pairs must be tested, so if this number is increased, test classes must be added
+        expectedNumPairs = 3;
+
         // set up all the variables for this pair
+        expectedPairIndex = 0;
         underlying = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1; // WETH
         cashAsset = 0xaf88d065e77c8cC2239327C5EDb3A432268e5831; // USDC
         offerAmount = 100_000e6;
@@ -51,6 +59,7 @@ contract WETHUSDCLoansForkTest is BaseLoansForkTest {
 contract WETHUSDTLoansForkTest is WETHUSDCLoansForkTest {
     function _setParams() internal virtual override {
         super._setParams();
+        expectedPairIndex = 1;
         underlying = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1; // WETH
         cashAsset = 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9; // USDT
     }
@@ -60,6 +69,7 @@ contract WBTCUSDTLoansForkTest is WETHUSDCLoansForkTest {
     function _setParams() internal virtual override {
         super._setParams();
 
+        expectedPairIndex = 2;
         underlying = 0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f; // WBTC
         cashAsset = 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9; // USDT
         underlyingAmount = 0.1e8;

--- a/test/unit/BaseAssetPairTestSetup.sol
+++ b/test/unit/BaseAssetPairTestSetup.sol
@@ -151,7 +151,7 @@ contract BaseAssetPairTestSetup is Test {
 
     function mintAssets() public {
         underlying.mint(user1, underlyingAmount * 10);
-        cashAsset.mint(user1, swapCashAmount * 10);
+        cashAsset.mint(user1, largeCash * 10);
         cashAsset.mint(provider, largeCash * 10);
         underlying.mint(supplier, largeUnderlying * 10);
     }

--- a/test/unit/BaseManaged.all.t.sol
+++ b/test/unit/BaseManaged.all.t.sol
@@ -41,7 +41,7 @@ abstract contract BaseManagedTestBase is Test {
     address guardian = makeAddr("guardian");
 
     function setUp() public virtual {
-        erc20 = new TestERC20("TestERC20", "TestERC20");
+        erc20 = new TestERC20("TestERC20", "TestERC20", 18);
         erc721 = new TestERC721();
         configHub = new ConfigHub(owner);
 

--- a/test/unit/CollarProviderNFT.t.sol
+++ b/test/unit/CollarProviderNFT.t.sol
@@ -22,7 +22,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     function setUp() public override {
         super.setUp();
         takerContract = address(takerNFT);
-        cashAsset.mint(takerContract, largeAmount * 10);
+        cashAsset.mint(takerContract, largeCash * 10);
     }
 
     function createAndCheckOffer(address provider, uint amount)
@@ -229,19 +229,19 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     /// Happy paths
 
     function test_createOffer() public returns (uint offerId) {
-        (offerId,) = createAndCheckOffer(provider, largeAmount);
+        (offerId,) = createAndCheckOffer(provider, largeCash);
     }
 
     function test_updateOfferAmountIncrease() public {
         // start from an existing offer
-        (uint offerId,) = createAndCheckOffer(provider, largeAmount);
+        (uint offerId,) = createAndCheckOffer(provider, largeCash);
 
-        cashAsset.approve(address(providerNFT), largeAmount);
-        uint newAmount = largeAmount * 2;
+        cashAsset.approve(address(providerNFT), largeCash);
+        uint newAmount = largeCash * 2;
         uint balance = cashAsset.balanceOf(provider);
 
         vm.expectEmit(address(providerNFT));
-        emit ICollarProviderNFT.OfferUpdated(offerId, provider, largeAmount, newAmount);
+        emit ICollarProviderNFT.OfferUpdated(offerId, provider, largeCash, newAmount);
         providerNFT.updateOfferAmount(offerId, newAmount);
 
         // next offer id not impacted
@@ -249,23 +249,23 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         // offer
         CollarProviderNFT.LiquidityOffer memory offer = providerNFT.getOffer(offerId);
         assertEq(offer.provider, provider);
-        assertEq(offer.available, largeAmount * 2);
+        assertEq(offer.available, largeCash * 2);
         assertEq(offer.putStrikePercent, putPercent);
         assertEq(offer.callStrikePercent, callStrikePercent);
         assertEq(offer.duration, duration);
         // balance
-        assertEq(cashAsset.balanceOf(provider), balance - largeAmount);
+        assertEq(cashAsset.balanceOf(provider), balance - largeCash);
     }
 
     function test_updateOfferAmountDecrease() public {
         // start from an existing offer
-        (uint offerId,) = createAndCheckOffer(provider, largeAmount);
+        (uint offerId,) = createAndCheckOffer(provider, largeCash);
 
-        uint newAmount = largeAmount / 2;
+        uint newAmount = largeCash / 2;
         uint balance = cashAsset.balanceOf(provider);
 
         vm.expectEmit(address(providerNFT));
-        emit ICollarProviderNFT.OfferUpdated(offerId, provider, largeAmount, newAmount);
+        emit ICollarProviderNFT.OfferUpdated(offerId, provider, largeCash, newAmount);
         providerNFT.updateOfferAmount(offerId, newAmount);
 
         // next offer id not impacted
@@ -273,22 +273,22 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         // offer
         CollarProviderNFT.LiquidityOffer memory offer = providerNFT.getOffer(offerId);
         assertEq(offer.provider, provider);
-        assertEq(offer.available, largeAmount / 2);
+        assertEq(offer.available, largeCash / 2);
         assertEq(offer.putStrikePercent, putPercent);
         assertEq(offer.callStrikePercent, callStrikePercent);
         assertEq(offer.duration, duration);
         // balance
-        assertEq(cashAsset.balanceOf(provider), balance + largeAmount / 2);
+        assertEq(cashAsset.balanceOf(provider), balance + largeCash / 2);
     }
 
     function test_updateOfferAmountNoChange() public {
         (uint offerId, CollarProviderNFT.LiquidityOffer memory previousOffer) =
-            createAndCheckOffer(provider, largeAmount);
+            createAndCheckOffer(provider, largeCash);
         uint balance = cashAsset.balanceOf(provider);
 
         vm.expectEmit(address(providerNFT));
-        emit ICollarProviderNFT.OfferUpdated(offerId, provider, largeAmount, largeAmount);
-        providerNFT.updateOfferAmount(offerId, largeAmount);
+        emit ICollarProviderNFT.OfferUpdated(offerId, provider, largeCash, largeCash);
+        providerNFT.updateOfferAmount(offerId, largeCash);
 
         assertEq(abi.encode(providerNFT.getOffer(offerId)), abi.encode(previousOffer));
         // balance
@@ -296,18 +296,18 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     }
 
     function test_updateOffer_fullAmount() public {
-        (uint offerId,) = createAndCheckOffer(provider, largeAmount);
+        (uint offerId,) = createAndCheckOffer(provider, largeCash);
         vm.startPrank(provider);
         providerNFT.updateOfferAmount(offerId, 0);
         assertEq(providerNFT.getOffer(offerId).available, 0);
     }
 
     function test_mintPositionFromOffer() public {
-        createAndCheckPosition(provider, largeAmount, largeAmount / 2);
+        createAndCheckPosition(provider, largeCash, largeCash / 2);
     }
 
     function test_tokenURI() public {
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, largeAmount / 2);
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, largeCash / 2);
         string memory expected = string.concat(
             "https://services.collarprotocol.xyz/metadata/",
             Strings.toString(block.chainid),
@@ -320,18 +320,18 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     }
 
     function test_mintPositionFromOffer_fullAmount() public {
-        uint fee = checkProtocolFeeView(largeAmount);
+        uint fee = checkProtocolFeeView(largeCash);
         cashAsset.mint(provider, fee);
-        createAndCheckPosition(provider, largeAmount + fee, largeAmount);
+        createAndCheckPosition(provider, largeCash + fee, largeCash);
     }
 
     function test_mintFromOffer_minLocked() public {
         // 0 amount works when minLocked = 0
-        createAndCheckPosition(provider, largeAmount, 0);
+        createAndCheckPosition(provider, largeCash, 0);
 
         // check non-zero minLocked effects (event)
-        minLocked = largeAmount / 2;
-        createAndCheckPosition(provider, largeAmount, largeAmount / 2);
+        minLocked = largeCash / 2;
+        createAndCheckPosition(provider, largeCash, largeCash / 2);
     }
 
     function test_protocolFee_zeroAddressRecipient() public {
@@ -341,7 +341,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
 
         // expect zero fee in createAndCheckPosition()
         expectNonZeroFee = false;
-        uint amount = 1 ether;
+        uint amount = cashUnits(1);
 
         // zero recipient, non-zero fee (prevented by config-hub setter, so needs to be mocked)
         vm.mockCall(address(configHub), abi.encodeCall(configHub.feeRecipient, ()), abi.encode(address(0)));
@@ -352,7 +352,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         uint feeChecked = checkProtocolFeeView(amount);
         assertEq(feeChecked, 0);
         // check minting with 0 recipient non-zero APR works (doesn't try to transfer to zero-address)
-        createAndCheckPosition(provider, largeAmount, amount);
+        createAndCheckPosition(provider, largeCash, amount);
     }
 
     function test_protocolFee_nonDefaultValues() public {
@@ -363,7 +363,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         // zero APR
         vm.startPrank(owner);
         configHub.setProtocolFeeParams(0, protocolFeeRecipient);
-        (uint fee, address feeRecipient) = providerNFT.protocolFee(largeAmount, duration);
+        (uint fee, address feeRecipient) = providerNFT.protocolFee(largeCash, duration);
         assertEq(feeRecipient, protocolFeeRecipient);
         assertEq(fee, 0);
 
@@ -380,49 +380,49 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
 
         // check calculation for specific hardcoded value
         configHub.setProtocolFeeParams(50, feeRecipient); // 0.5% per year
-        (fee,) = providerNFT.protocolFee(10 ether, 365 days);
-        assertEq(fee, 0.05 ether);
-        (fee,) = providerNFT.protocolFee(10 ether + 1, 365 days);
-        assertEq(fee, 0.05 ether + 1); // rounds up
+        (fee,) = providerNFT.protocolFee(cashUnits(10), 365 days);
+        assertEq(fee, cashFraction(0.05 ether));
+        (fee,) = providerNFT.protocolFee(cashUnits(10) + 1, 365 days);
+        assertEq(fee, cashFraction(0.05 ether) + 1); // rounds up
     }
 
     function test_settlePositionIncrease() public {
-        uint amountToMint = largeAmount / 2;
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, amountToMint);
+        uint amountToMint = largeCash / 2;
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, amountToMint);
 
         skip(duration);
 
-        checkSettlePosition(positionId, amountToMint, 1000 ether);
+        checkSettlePosition(positionId, amountToMint, int(cashUnits(1000)));
     }
 
     function test_settlePositionDecrease() public {
-        uint amountToMint = largeAmount / 2;
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, amountToMint);
+        uint amountToMint = largeCash / 2;
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, amountToMint);
 
         skip(duration);
 
-        checkSettlePosition(positionId, amountToMint, -1000 ether);
+        checkSettlePosition(positionId, amountToMint, -int(cashUnits(1000)));
     }
 
     function test_settlePosition_expirationTimeSensitivity() public {
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, largeAmount / 2);
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, largeCash / 2);
         skip(duration + 1); // 1 second after expiration still works
-        checkSettlePosition(positionId, largeAmount / 2, -1 ether);
+        checkSettlePosition(positionId, largeCash / 2, -int(cashUnits(1)));
     }
 
     function test_settlePosition_maxLoss() public {
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, largeAmount / 2);
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, largeCash / 2);
         skip(duration);
-        checkSettlePosition(positionId, largeAmount / 2, -int(largeAmount / 2));
+        checkSettlePosition(positionId, largeCash / 2, -int(largeCash / 2));
         assertEq(providerNFT.getPosition(positionId).withdrawable, 0);
     }
 
     function test_withdrawFromSettled() public {
         // create settled position
-        uint amountToMint = largeAmount / 2;
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, amountToMint);
+        uint amountToMint = largeCash / 2;
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, amountToMint);
         skip(duration);
-        int positionChange = 1000 ether;
+        int positionChange = int(cashUnits(1000));
 
         uint withdrawable = checkSettlePosition(positionId, amountToMint, positionChange);
 
@@ -430,8 +430,8 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     }
 
     function test_settleAndWithdraw_removedTaker() public {
-        uint amountToMint = largeAmount / 2;
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, amountToMint);
+        uint amountToMint = largeCash / 2;
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, amountToMint);
         skip(duration);
         setCanOpen(takerContract, false);
         // should work
@@ -441,14 +441,14 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     }
 
     function test_cancelAndWithdraw() public {
-        uint amountToMint = largeAmount / 2;
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, amountToMint);
+        uint amountToMint = largeCash / 2;
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, amountToMint);
         checkCancelAndWithdraw(positionId, amountToMint);
     }
 
     function test_cancelAndWithdraw_removedTaker() public {
-        uint amountToMint = largeAmount / 2;
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, amountToMint);
+        uint amountToMint = largeCash / 2;
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, amountToMint);
         skip(duration);
         setCanOpen(takerContract, false);
         // should work
@@ -456,9 +456,9 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     }
 
     function test_cancelAndWithdraw_afterExpiration() public {
-        uint amountToMint = largeAmount / 2;
+        uint amountToMint = largeCash / 2;
         (uint positionId, CollarProviderNFT.ProviderPosition memory position) =
-            createAndCheckPosition(provider, largeAmount, amountToMint);
+            createAndCheckPosition(provider, largeCash, amountToMint);
 
         skip(duration + 1);
 
@@ -472,21 +472,21 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     }
 
     function test_cancelAndWithdraw_approvals() public {
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, largeAmount / 10);
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, largeCash / 10);
         // approve of ID works
         vm.startPrank(provider);
         providerNFT.approve(takerContract, positionId);
         vm.startPrank(takerContract);
         providerNFT.cancelAndWithdraw(positionId);
 
-        (positionId,) = createAndCheckPosition(provider, largeAmount, largeAmount / 10);
+        (positionId,) = createAndCheckPosition(provider, largeCash, largeCash / 10);
         // ownership works
         vm.startPrank(provider);
         providerNFT.transferFrom(provider, takerContract, positionId);
         vm.startPrank(takerContract);
         providerNFT.cancelAndWithdraw(positionId);
 
-        (positionId,) = createAndCheckPosition(provider, largeAmount, largeAmount / 10);
+        (positionId,) = createAndCheckPosition(provider, largeCash, largeCash / 10);
         // setApprovalForAll works
         vm.startPrank(provider);
         providerNFT.setApprovalForAll(takerContract, true);
@@ -502,7 +502,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         providerNFT.unpause();
         assertFalse(providerNFT.paused());
         // check at least one method workds now
-        createAndCheckOffer(provider, largeAmount);
+        createAndCheckOffer(provider, largeCash);
     }
 
     /// Interactions between multiple items
@@ -512,14 +512,14 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         uint[] memory offerIds = new uint[](offerCount);
 
         for (uint i = 0; i < offerCount; i++) {
-            uint amount = largeAmount / (i + 1);
+            uint amount = largeCash / (i + 1);
             (offerIds[i],) = createAndCheckOffer(provider, amount);
         }
 
         for (uint i = 0; i < offerCount; i++) {
             CollarProviderNFT.LiquidityOffer memory offer = providerNFT.getOffer(offerIds[i]);
             assertEq(offer.provider, provider);
-            assertEq(offer.available, largeAmount / (i + 1));
+            assertEq(offer.available, largeCash / (i + 1));
             assertEq(offer.putStrikePercent, putPercent);
             assertEq(offer.callStrikePercent, callStrikePercent);
             assertEq(offer.duration, duration);
@@ -531,15 +531,15 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     function test_mintMultiplePositionsFromSameOffer() public {
         uint positionCount = 3;
         uint[] memory positionIds = new uint[](positionCount);
-        uint fee = checkProtocolFeeView(largeAmount);
-        uint offerAmount = (largeAmount + fee) * positionCount;
+        uint fee = checkProtocolFeeView(largeCash);
+        uint offerAmount = (largeCash + fee) * positionCount;
         uint feeRecipientBalance = cashAsset.balanceOf(protocolFeeRecipient);
 
         (uint offerId,) = createAndCheckOffer(provider, offerAmount);
 
         vm.startPrank(address(takerContract));
         for (uint i = 0; i < positionCount; i++) {
-            uint amount = largeAmount;
+            uint amount = largeCash;
             positionIds[i] = providerNFT.mintFromOffer(offerId, amount, i);
         }
 
@@ -552,7 +552,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
             CollarProviderNFT.ProviderPosition memory position = providerNFT.getPosition(positionIds[i]);
             assertEq(position.offerId, offerId);
             assertEq(position.takerId, i);
-            assertEq(position.providerLocked, largeAmount);
+            assertEq(position.providerLocked, largeCash);
             assertEq(position.putStrikePercent, putPercent);
             assertEq(position.callStrikePercent, callStrikePercent);
             assertEq(position.settled, false);
@@ -568,7 +568,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
 
         // Create and mint a position
         (uint positionId, CollarProviderNFT.ProviderPosition memory position) =
-            createAndCheckPosition(provider, largeAmount, largeAmount / 2);
+            createAndCheckPosition(provider, largeCash, largeCash / 2);
 
         // Transfer the position to the new owner
         vm.startPrank(provider);
@@ -580,7 +580,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         skip(duration);
 
         // Settle the position
-        int positionChange = 1000 ether;
+        int positionChange = int(cashUnits(1000));
         vm.startPrank(address(takerContract));
         cashAsset.approve(address(providerNFT), uint(positionChange));
         providerNFT.settlePosition(positionId, positionChange);
@@ -610,7 +610,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
 
     function test_pausableMethods() public {
         // create a position
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, largeAmount / 2);
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, largeCash / 2);
 
         // pause
         vm.startPrank(owner);
@@ -649,27 +649,27 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     function test_revert_createOffer_invalidParams() public {
         uint minStrike = providerNFT.MIN_CALL_STRIKE_BIPS();
         vm.expectRevert("provider: strike percent too low");
-        providerNFT.createOffer(minStrike - 1, largeAmount, putPercent, duration, minLocked);
+        providerNFT.createOffer(minStrike - 1, largeCash, putPercent, duration, minLocked);
 
         uint maxStrike = providerNFT.MAX_CALL_STRIKE_BIPS();
         vm.expectRevert("provider: strike percent too high");
-        providerNFT.createOffer(maxStrike + 1, largeAmount, putPercent, duration, minLocked);
+        providerNFT.createOffer(maxStrike + 1, largeCash, putPercent, duration, minLocked);
 
         uint maxPutStrike = providerNFT.MAX_PUT_STRIKE_BIPS();
         vm.expectRevert("provider: invalid put strike percent");
-        providerNFT.createOffer(callStrikePercent, largeAmount, maxPutStrike + 1, duration, minLocked);
+        providerNFT.createOffer(callStrikePercent, largeCash, maxPutStrike + 1, duration, minLocked);
     }
 
     function test_revert_updateOfferAmount() public {
-        (uint offerId,) = createAndCheckOffer(provider, largeAmount);
+        (uint offerId,) = createAndCheckOffer(provider, largeCash);
 
         vm.startPrank(address(0xdead));
         vm.expectRevert("provider: not offer provider");
-        providerNFT.updateOfferAmount(offerId, largeAmount * 2);
+        providerNFT.updateOfferAmount(offerId, largeCash * 2);
     }
 
     function test_revert_mintPositionFromOffer_configFlags() public {
-        (uint offerId,) = createAndCheckOffer(provider, largeAmount);
+        (uint offerId,) = createAndCheckOffer(provider, largeCash);
 
         vm.startPrank(address(0xdead));
         vm.expectRevert("provider: unauthorized taker contract");
@@ -701,45 +701,45 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
 
     function test_revert_mintFromOffer_ConfigHubValidations() public {
         // set a putpercent that willbe invalid later
-        (uint offerId,) = createAndCheckOffer(provider, largeAmount);
+        (uint offerId,) = createAndCheckOffer(provider, largeCash);
         vm.startPrank(owner);
         putPercent = putPercent + 100;
         configHub.setLTVRange(putPercent, putPercent);
         vm.startPrank(address(takerContract));
         vm.expectRevert("provider: unsupported LTV");
-        providerNFT.mintFromOffer(offerId, largeAmount / 2, 0);
+        providerNFT.mintFromOffer(offerId, largeCash / 2, 0);
         vm.startPrank(owner);
         putPercent = 9000;
         configHub.setLTVRange(putPercent, configHub.maxLTV());
         // set a duration that will be invalid later
         configHub.setCollarDurationRange(duration, configHub.maxDuration());
-        (offerId,) = createAndCheckOffer(provider, largeAmount);
+        (offerId,) = createAndCheckOffer(provider, largeCash);
         vm.startPrank(owner);
         duration = duration + 100;
         configHub.setCollarDurationRange(duration, duration);
         vm.startPrank(address(takerContract));
         vm.expectRevert("provider: unsupported duration");
-        providerNFT.mintFromOffer(offerId, largeAmount / 2, 0);
+        providerNFT.mintFromOffer(offerId, largeCash / 2, 0);
     }
 
     function test_revert_mintPositionFromOffer_amountTooHigh() public {
-        (uint offerId,) = createAndCheckOffer(provider, largeAmount);
+        (uint offerId,) = createAndCheckOffer(provider, largeCash);
 
         vm.startPrank(address(takerContract));
         vm.expectRevert("provider: amount too high");
-        providerNFT.mintFromOffer(offerId, largeAmount + 1, 0);
+        providerNFT.mintFromOffer(offerId, largeCash + 1, 0);
     }
 
     function test_revert_mintFromOffer_amountTooLow() public {
         minLocked = 1;
-        (uint offerId,) = createAndCheckOffer(provider, largeAmount);
+        (uint offerId,) = createAndCheckOffer(provider, largeCash);
 
         vm.startPrank(address(takerContract));
         vm.expectRevert("provider: amount too low");
         providerNFT.mintFromOffer(offerId, 0, 0);
 
-        minLocked = largeAmount / 2;
-        (offerId,) = createAndCheckOffer(provider, largeAmount);
+        minLocked = largeCash / 2;
+        (offerId,) = createAndCheckOffer(provider, largeCash);
 
         vm.startPrank(address(takerContract));
         vm.expectRevert("provider: amount too low");
@@ -747,7 +747,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     }
 
     function test_revert_settlePosition() public {
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, largeAmount / 2);
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, largeCash / 2);
 
         vm.startPrank(address(0xdead));
         vm.expectRevert("provider: unauthorized taker contract");
@@ -763,7 +763,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         skip(duration);
 
         vm.expectRevert("provider: loss is too high");
-        providerNFT.settlePosition(positionId, -int(largeAmount / 2 + 1));
+        providerNFT.settlePosition(positionId, -int(largeCash / 2 + 1));
 
         vm.expectRevert(stdError.arithmeticError);
         providerNFT.settlePosition(positionId, type(int).min);
@@ -787,7 +787,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     }
 
     function test_revert_settlePosition_afterCancel() public {
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, largeAmount / 2);
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, largeCash / 2);
 
         skip(duration);
 
@@ -803,7 +803,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     }
 
     function test_revert_withdrawFromSettled() public {
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, largeAmount / 2);
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, largeCash / 2);
 
         // not yet minted
         expectRevertERC721Nonexistent(positionId + 1);
@@ -821,7 +821,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     }
 
     function test_revert_cancelAndWithdraw() public {
-        (uint positionId,) = createAndCheckPosition(provider, largeAmount, largeAmount / 2);
+        (uint positionId,) = createAndCheckPosition(provider, largeCash, largeCash / 2);
 
         vm.startPrank(address(0xdead));
         vm.expectRevert("provider: unauthorized taker contract");

--- a/test/unit/ConfigHub.t.sol
+++ b/test/unit/ConfigHub.t.sol
@@ -26,8 +26,8 @@ contract ConfigHubTest is Test {
     bytes user1NotAuthorized = abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user1);
 
     function setUp() public {
-        token1 = new TestERC20("Test1", "TST1");
-        token2 = new TestERC20("Test2", "TST2");
+        token1 = new TestERC20("Test1", "TST1", 18);
+        token2 = new TestERC20("Test2", "TST2", 18);
         configHub = new ConfigHub(owner);
     }
 

--- a/test/unit/EscrowSupplier.admin.t.sol
+++ b/test/unit/EscrowSupplier.admin.t.sol
@@ -43,7 +43,7 @@ contract EscrowSupplierNFT_AdminTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_paused_methods() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeAmount, largeAmount, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying, 1 ether);
 
         // pause
         vm.startPrank(owner);
@@ -92,6 +92,6 @@ contract EscrowSupplierNFT_AdminTest is BaseEscrowSupplierNFTTest {
         escrowNFT.unpause();
         assertFalse(escrowNFT.paused());
         // check at least one method workds now
-        createAndCheckOffer(supplier1, largeAmount);
+        createAndCheckOffer(supplier1, largeUnderlying);
     }
 }

--- a/test/unit/EscrowSupplierNFT.effects.t.sol
+++ b/test/unit/EscrowSupplierNFT.effects.t.sol
@@ -35,9 +35,9 @@ contract BaseEscrowSupplierNFTTest is BaseAssetPairTestSetup {
         escrowNFT.setLoansCanOpen(loans, true);
         vm.stopPrank();
 
-        asset.mint(loans, largeAmount * 10);
-        asset.mint(supplier1, largeAmount * 10);
-        asset.mint(supplier2, largeAmount * 10);
+        asset.mint(loans, largeUnderlying * 10);
+        asset.mint(supplier1, largeUnderlying * 10);
+        asset.mint(supplier2, largeUnderlying * 10);
         // mint dust (as in mintDustToContracts)
         asset.mint(address(escrowNFT), 1);
     }
@@ -77,14 +77,14 @@ contract BaseEscrowSupplierNFTTest is BaseAssetPairTestSetup {
     }
 
     function checkUpdateOfferAmount(int delta) internal {
-        (uint offerId,) = createAndCheckOffer(supplier1, largeAmount);
+        (uint offerId,) = createAndCheckOffer(supplier1, largeUnderlying);
 
-        asset.approve(address(escrowNFT), largeAmount);
-        uint newAmount = delta > 0 ? largeAmount + uint(delta) : largeAmount - uint(-delta);
+        asset.approve(address(escrowNFT), largeUnderlying);
+        uint newAmount = delta > 0 ? largeUnderlying + uint(delta) : largeUnderlying - uint(-delta);
         uint balance = asset.balanceOf(address(escrowNFT));
 
         vm.expectEmit(address(escrowNFT));
-        emit IEscrowSupplierNFT.OfferUpdated(offerId, supplier1, largeAmount, newAmount);
+        emit IEscrowSupplierNFT.OfferUpdated(offerId, supplier1, largeUnderlying, newAmount);
         escrowNFT.updateOfferAmount(offerId, newAmount);
 
         // next offer id not impacted
@@ -98,7 +98,7 @@ contract BaseEscrowSupplierNFTTest is BaseAssetPairTestSetup {
         assertEq(offer.maxGracePeriod, maxGracePeriod);
         assertEq(offer.lateFeeAPR, lateFeeAPR);
         // balance
-        assertEq(asset.balanceOf(address(escrowNFT)), balance + newAmount - largeAmount);
+        assertEq(asset.balanceOf(address(escrowNFT)), balance + newAmount - largeUnderlying);
     }
 
     function createAndCheckEscrow(address supplier, uint offerAmount, uint escrowAmount, uint fee)
@@ -241,9 +241,9 @@ contract BaseEscrowSupplierNFTTest is BaseAssetPairTestSetup {
     }
 
     function checkLastResortSeizeEscrow(uint delay) public {
-        uint escrowAmount = largeAmount / 2;
+        uint escrowAmount = largeUnderlying / 2;
         uint fee = 1 ether;
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeAmount, escrowAmount, fee);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, escrowAmount, fee);
 
         // Skip past expiration and grace period
         skip(duration + maxGracePeriod + 1 + delay);
@@ -281,7 +281,7 @@ contract BaseEscrowSupplierNFTTest is BaseAssetPairTestSetup {
         uint toSkip,
         ExpectedRelease memory expected
     ) public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeAmount, escrowAmount, fee);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, escrowAmount, fee);
         skip(toSkip);
         // check preview
         (uint withdrawable, uint toLoans, uint refund) = escrowNFT.previewRelease(escrowId, repaid);
@@ -331,37 +331,37 @@ contract EscrowSupplierNFT_BasicEffectsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_createOffer() public {
-        createAndCheckOffer(supplier1, largeAmount);
+        createAndCheckOffer(supplier1, largeUnderlying);
 
         // another one (multiple offers)
-        createAndCheckOffer(supplier1, largeAmount);
+        createAndCheckOffer(supplier1, largeUnderlying);
 
         // max values ok
         interestAPR = escrowNFT.MAX_INTEREST_APR_BIPS();
         maxGracePeriod = escrowNFT.MAX_GRACE_PERIOD();
         lateFeeAPR = escrowNFT.MAX_LATE_FEE_APR_BIPS();
-        createAndCheckOffer(supplier1, largeAmount);
+        createAndCheckOffer(supplier1, largeUnderlying);
     }
 
     function test_updateOfferAmount() public {
-        checkUpdateOfferAmount(int(largeAmount));
+        checkUpdateOfferAmount(int(largeUnderlying));
 
-        checkUpdateOfferAmount(int(largeAmount) / 2);
+        checkUpdateOfferAmount(int(largeUnderlying) / 2);
 
-        checkUpdateOfferAmount(-int(largeAmount));
+        checkUpdateOfferAmount(-int(largeUnderlying));
 
-        checkUpdateOfferAmount(-int(largeAmount) / 2);
+        checkUpdateOfferAmount(-int(largeUnderlying) / 2);
 
         checkUpdateOfferAmount(0);
     }
 
     function test_startEscrow_simple() public {
         uint fee = 1 ether; // arbitrary
-        createAndCheckEscrow(supplier1, largeAmount, largeAmount / 2, fee);
+        createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying / 2, fee);
     }
 
     function test_tokenURI() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeAmount, largeAmount / 2, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying / 2, 1 ether);
         string memory expected = string.concat(
             "https://services.collarprotocol.xyz/metadata/",
             Strings.toString(block.chainid),
@@ -375,8 +375,8 @@ contract EscrowSupplierNFT_BasicEffectsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_multipleEscrowsFromSameOffer() public {
-        uint offerAmount = largeAmount;
-        uint escrowAmount = largeAmount / 4;
+        uint offerAmount = largeUnderlying;
+        uint escrowAmount = largeUnderlying / 4;
         uint fee = 1 ether;
 
         (uint offerId,) = createAndCheckOffer(supplier1, offerAmount);
@@ -388,7 +388,7 @@ contract EscrowSupplierNFT_BasicEffectsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_startEscrow_switchEscrow_minEscrow() public {
-        (uint offerId,) = createAndCheckOffer(supplier1, largeAmount);
+        (uint offerId,) = createAndCheckOffer(supplier1, largeUnderlying);
         // 0 amount works for startEscrow when minEscrow = 0
         (uint escrowId,) = createAndCheckEscrowFromOffer(offerId, 0, 0);
         // 0 amount works for switchEscrow when minEscrow = 0
@@ -396,9 +396,9 @@ contract EscrowSupplierNFT_BasicEffectsTest is BaseEscrowSupplierNFTTest {
         escrowNFT.switchEscrow(escrowId, offerId, 0, 0);
 
         uint fee = 1 ether;
-        minEscrow = largeAmount / 10;
+        minEscrow = largeUnderlying / 10;
         // check non-zero minLocked effects (event)
-        (offerId,) = createAndCheckOffer(supplier1, largeAmount);
+        (offerId,) = createAndCheckOffer(supplier1, largeUnderlying);
         (escrowId,) = createAndCheckEscrowFromOffer(offerId, minEscrow, fee);
         startHoax(loans);
         asset.approve(address(escrowNFT), fee);
@@ -406,7 +406,7 @@ contract EscrowSupplierNFT_BasicEffectsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_endEscrow_withdrawReleased_simple() public {
-        uint escrowed = largeAmount / 2;
+        uint escrowed = largeUnderlying / 2;
         uint fee = 1 ether;
 
         // after full duration
@@ -421,7 +421,7 @@ contract EscrowSupplierNFT_BasicEffectsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_endEscrow_withdrawReleased_underRepay() public {
-        uint escrowed = largeAmount / 2;
+        uint escrowed = largeUnderlying / 2;
         uint fee = 1 ether;
 
         // 0 repayment immediate release (cancellation)
@@ -457,7 +457,7 @@ contract EscrowSupplierNFT_BasicEffectsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_endEscrow_withdrawReleased_overPay() public {
-        uint escrowed = largeAmount / 2;
+        uint escrowed = largeUnderlying / 2;
         uint fee = 1 ether;
         uint halfFee = fee / 2;
         check_preview_end_withdraw(
@@ -485,12 +485,13 @@ contract EscrowSupplierNFT_BasicEffectsTest is BaseEscrowSupplierNFTTest {
 
     function test_switchEscrow_simple() public {
         Amounts memory amounts;
-        amounts.escrowAmount = largeAmount / 2;
+        amounts.escrowAmount = largeUnderlying / 2;
         amounts.fee = 1 ether;
-        (uint oldEscrowId,) = createAndCheckEscrow(supplier1, largeAmount, amounts.escrowAmount, amounts.fee);
+        (uint oldEscrowId,) =
+            createAndCheckEscrow(supplier1, largeUnderlying, amounts.escrowAmount, amounts.fee);
 
         amounts.newFee = amounts.fee * 2;
-        (uint newOfferId,) = createAndCheckOffer(supplier2, largeAmount);
+        (uint newOfferId,) = createAndCheckOffer(supplier2, largeUnderlying);
 
         uint newLoanId = 1000; // arbitrary
 
@@ -553,10 +554,10 @@ contract EscrowSupplierNFT_BasicEffectsTest is BaseEscrowSupplierNFTTest {
     // view effects
 
     function test_lateFees() public {
-        uint escrowAmount = largeAmount / 2;
+        uint escrowAmount = largeUnderlying / 2;
         uint fee = 1 ether;
         (uint escrowId, EscrowSupplierNFT.Escrow memory escrow) =
-            createAndCheckEscrow(supplier1, largeAmount, escrowAmount, fee);
+            createAndCheckEscrow(supplier1, largeUnderlying, escrowAmount, fee);
 
         // late fee are expected
         assertGt(escrowNFT.getEscrow(escrowId).lateFeeAPR, 0);
@@ -593,17 +594,17 @@ contract EscrowSupplierNFT_BasicEffectsTest is BaseEscrowSupplierNFTTest {
 
         // APR 0
         lateFeeAPR = 0;
-        (escrowId, escrow) = createAndCheckEscrow(supplier1, largeAmount, escrowAmount, fee);
+        (escrowId, escrow) = createAndCheckEscrow(supplier1, largeUnderlying, escrowAmount, fee);
         skip(duration + 365 days);
         (, feeAfterGracePeriod) = escrowNFT.currentOwed(escrowId);
         assertEq(feeAfterGracePeriod, 0);
     }
 
     function test_gracePeriodFromFees() public {
-        uint escrowAmount = largeAmount / 2;
+        uint escrowAmount = largeUnderlying / 2;
         uint fee = 1 ether;
         (uint escrowId, EscrowSupplierNFT.Escrow memory escrow) =
-            createAndCheckEscrow(supplier1, largeAmount, escrowAmount, fee);
+            createAndCheckEscrow(supplier1, largeUnderlying, escrowAmount, fee);
 
         // Full grace period when fee amount covers it
         uint fullGracePeriod = escrowNFT.cappedGracePeriod(escrowId, escrowAmount);
@@ -623,20 +624,20 @@ contract EscrowSupplierNFT_BasicEffectsTest is BaseEscrowSupplierNFTTest {
 
         // lateFeeAPR 0
         lateFeeAPR = 0;
-        (uint newEscrowId,) = createAndCheckEscrow(supplier1, largeAmount, escrowAmount, fee);
+        (uint newEscrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, escrowAmount, fee);
         // full grace period even with no fee
         assertEq(escrowNFT.cappedGracePeriod(newEscrowId, 0), maxGracePeriod);
     }
 
     function test_interestFee_noFee() public {
-        (uint offerId,) = createAndCheckOffer(supplier, largeAmount);
+        (uint offerId,) = createAndCheckOffer(supplier, largeUnderlying);
 
         // zero escrow amount
         assertEq(escrowNFT.interestFee(offerId, 0), 0);
 
         // zero APR
         interestAPR = 0;
-        (offerId,) = createAndCheckOffer(supplier, largeAmount);
-        assertEq(escrowNFT.interestFee(offerId, largeAmount), 0);
+        (offerId,) = createAndCheckOffer(supplier, largeUnderlying);
+        assertEq(escrowNFT.interestFee(offerId, largeUnderlying), 0);
     }
 }

--- a/test/unit/EscrowSupplierNFT.reverts.t.sol
+++ b/test/unit/EscrowSupplierNFT.reverts.t.sol
@@ -9,79 +9,79 @@ import { BaseEscrowSupplierNFTTest } from "./EscrowSupplierNFT.effects.t.sol";
 contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
     function test_revert_createOffer_invalidParams() public {
         startHoax(supplier1);
-        asset.approve(address(escrowNFT), largeAmount);
+        asset.approve(address(escrowNFT), largeUnderlying);
 
         uint val = escrowNFT.MAX_INTEREST_APR_BIPS();
         vm.expectRevert("escrow: interest APR too high");
-        escrowNFT.createOffer(largeAmount, duration, val + 1, maxGracePeriod, lateFeeAPR, 0);
+        escrowNFT.createOffer(largeUnderlying, duration, val + 1, maxGracePeriod, lateFeeAPR, 0);
 
         val = escrowNFT.MIN_GRACE_PERIOD();
         vm.expectRevert("escrow: grace period too short");
-        escrowNFT.createOffer(largeAmount, duration, interestAPR, val - 1, lateFeeAPR, 0);
+        escrowNFT.createOffer(largeUnderlying, duration, interestAPR, val - 1, lateFeeAPR, 0);
 
         val = escrowNFT.MAX_GRACE_PERIOD();
         vm.expectRevert("escrow: grace period too long");
-        escrowNFT.createOffer(largeAmount, duration, interestAPR, val + 1, lateFeeAPR, 0);
+        escrowNFT.createOffer(largeUnderlying, duration, interestAPR, val + 1, lateFeeAPR, 0);
 
         val = escrowNFT.MAX_LATE_FEE_APR_BIPS();
         vm.expectRevert("escrow: late fee APR too high");
-        escrowNFT.createOffer(largeAmount, duration, interestAPR, maxGracePeriod, val + 1, 0);
+        escrowNFT.createOffer(largeUnderlying, duration, interestAPR, maxGracePeriod, val + 1, 0);
     }
 
     function test_revert_updateOfferAmount_notSupplier() public {
-        (uint offerId,) = createAndCheckOffer(supplier1, largeAmount);
+        (uint offerId,) = createAndCheckOffer(supplier1, largeUnderlying);
 
         startHoax(supplier2);
         vm.expectRevert("escrow: not offer supplier");
-        escrowNFT.updateOfferAmount(offerId, largeAmount / 2);
+        escrowNFT.updateOfferAmount(offerId, largeUnderlying / 2);
     }
 
     function test_revert_startEscrow_minEscrow() public {
         minEscrow = 1;
-        (uint offerId,) = createAndCheckOffer(supplier1, largeAmount);
+        (uint offerId,) = createAndCheckOffer(supplier1, largeUnderlying);
 
         startHoax(loans);
         vm.expectRevert("escrow: amount too low");
         escrowNFT.startEscrow(offerId, 0, 0, 0);
 
-        minEscrow = largeAmount / 2;
+        minEscrow = largeUnderlying / 2;
         uint fee = 1 ether;
-        (offerId,) = createAndCheckOffer(supplier1, largeAmount);
+        (offerId,) = createAndCheckOffer(supplier1, largeUnderlying);
         startHoax(loans);
-        asset.approve(address(escrowNFT), largeAmount / 2);
+        asset.approve(address(escrowNFT), largeUnderlying / 2);
         vm.expectRevert("escrow: amount too low");
         escrowNFT.startEscrow(offerId, minEscrow - 1, fee, 0);
     }
 
     function test_revert_startEscrow_invalidParams() public {
-        (uint offerId,) = createAndCheckOffer(supplier1, largeAmount);
+        (uint offerId,) = createAndCheckOffer(supplier1, largeUnderlying);
 
         startHoax(loans);
-        asset.approve(address(escrowNFT), largeAmount);
+        asset.approve(address(escrowNFT), largeUnderlying);
 
         vm.expectRevert("escrow: amount too high");
-        escrowNFT.startEscrow(offerId, largeAmount + 1, 1 ether, 1000);
+        escrowNFT.startEscrow(offerId, largeUnderlying + 1, 1 ether, 1000);
 
-        uint minFee = escrowNFT.interestFee(offerId, largeAmount);
+        uint minFee = escrowNFT.interestFee(offerId, largeUnderlying);
         vm.expectRevert("escrow: insufficient fee");
-        escrowNFT.startEscrow(offerId, largeAmount, minFee - 1, 1000);
+        escrowNFT.startEscrow(offerId, largeUnderlying, minFee - 1, 1000);
 
         vm.expectRevert("escrow: invalid offer");
-        escrowNFT.startEscrow(offerId + 1, largeAmount, minFee, 1000);
+        escrowNFT.startEscrow(offerId + 1, largeUnderlying, minFee, 1000);
 
         vm.startPrank(owner);
         configHub.setCollarDurationRange(duration + 1, duration + 2);
         vm.startPrank(loans);
         vm.expectRevert("escrow: unsupported duration");
-        escrowNFT.startEscrow(offerId, largeAmount, 1 ether, 1000);
+        escrowNFT.startEscrow(offerId, largeUnderlying, 1 ether, 1000);
     }
 
     function test_revert_switchEscrow_minEscrow() public {
-        (uint offer1,) = createAndCheckOffer(supplier1, largeAmount);
+        (uint offer1,) = createAndCheckOffer(supplier1, largeUnderlying);
         minEscrow = 1;
-        (uint offer2,) = createAndCheckOffer(supplier1, largeAmount);
-        minEscrow = largeAmount / 2;
-        (uint offer3,) = createAndCheckOffer(supplier1, largeAmount);
+        (uint offer2,) = createAndCheckOffer(supplier1, largeUnderlying);
+        minEscrow = largeUnderlying / 2;
+        (uint offer3,) = createAndCheckOffer(supplier1, largeUnderlying);
 
         startHoax(loans);
         // dust escrow
@@ -91,21 +91,21 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         escrowNFT.switchEscrow(escrowId, offer2, 0, 0);
 
         uint fee = 1 ether;
-        asset.approve(address(escrowNFT), largeAmount / 2 + fee - 1);
-        (escrowId) = escrowNFT.startEscrow(offer1, largeAmount / 2 - 1, fee, 0);
+        asset.approve(address(escrowNFT), largeUnderlying / 2 + fee - 1);
+        (escrowId) = escrowNFT.startEscrow(offer1, largeUnderlying / 2 - 1, fee, 0);
         // switch to offer3, does not accept the amount
         vm.expectRevert("escrow: amount too low");
         escrowNFT.switchEscrow(escrowId, offer3, fee, 0);
     }
 
     function test_revert_switchEscrow_invalidParams() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeAmount, largeAmount, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying, 1 ether);
 
         startHoax(loans);
-        asset.approve(address(escrowNFT), largeAmount);
+        asset.approve(address(escrowNFT), largeUnderlying);
 
-        (uint newOfferId,) = createAndCheckOffer(supplier2, largeAmount - 1);
-        uint minFee = escrowNFT.interestFee(newOfferId, largeAmount - 1);
+        (uint newOfferId,) = createAndCheckOffer(supplier2, largeUnderlying - 1);
+        uint minFee = escrowNFT.interestFee(newOfferId, largeUnderlying - 1);
 
         // fee
         startHoax(loans);
@@ -115,7 +115,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         // new offer is insufficient
         vm.expectRevert("escrow: amount too high");
         escrowNFT.switchEscrow(escrowId, newOfferId, minFee, 0);
-        (newOfferId,) = createAndCheckOffer(supplier2, largeAmount);
+        (newOfferId,) = createAndCheckOffer(supplier2, largeUnderlying);
 
         startHoax(loans);
         vm.expectRevert("escrow: invalid offer");
@@ -159,12 +159,12 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_revert_startEscrow_unauthorizedLoans() public {
-        (uint offerId,) = createAndCheckOffer(supplier1, largeAmount);
+        (uint offerId,) = createAndCheckOffer(supplier1, largeUnderlying);
 
         setCanOpenSingle(address(escrowNFT), false);
         vm.startPrank(loans);
         vm.expectRevert("escrow: unsupported escrow");
-        escrowNFT.startEscrow(offerId, largeAmount / 2, 1 ether, 1000);
+        escrowNFT.startEscrow(offerId, largeUnderlying / 2, 1 ether, 1000);
 
         setCanOpenSingle(address(escrowNFT), true);
 
@@ -173,17 +173,17 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         escrowNFT.setLoansCanOpen(loans, false);
         vm.startPrank(loans);
         vm.expectRevert("escrow: unauthorized loans contract");
-        escrowNFT.startEscrow(offerId, largeAmount / 2, 1 ether, 1000);
+        escrowNFT.startEscrow(offerId, largeUnderlying / 2, 1 ether, 1000);
 
         // some other address
         startHoax(makeAddr("otherLoans"));
         vm.expectRevert("escrow: unauthorized loans contract");
-        escrowNFT.startEscrow(offerId, largeAmount / 2, 1 ether, 1000);
+        escrowNFT.startEscrow(offerId, largeUnderlying / 2, 1 ether, 1000);
     }
 
     function test_revert_switchEscrow_unauthorizedLoans() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeAmount, largeAmount, 1 ether);
-        (uint newOfferId,) = createAndCheckOffer(supplier2, largeAmount);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying, 1 ether);
+        (uint newOfferId,) = createAndCheckOffer(supplier2, largeUnderlying);
 
         setCanOpenSingle(address(escrowNFT), false);
         vm.startPrank(loans);
@@ -206,7 +206,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_revert_loansCanOpen_only_switchEscrow() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeAmount, largeAmount / 2, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying / 2, 1 ether);
 
         // removing loans canOpen prevents switchEscrow
         vm.startPrank(owner);
@@ -219,7 +219,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_revert_endEscrow_switchEscrow() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeAmount, largeAmount / 2, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying / 2, 1 ether);
 
         // not same loans that started
         vm.startPrank(owner);
@@ -236,8 +236,8 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         vm.startPrank(owner);
         escrowNFT.setLoansCanOpen(loans, true);
         vm.startPrank(loans);
-        asset.approve(address(escrowNFT), largeAmount);
-        escrowNFT.endEscrow(escrowId, largeAmount / 2);
+        asset.approve(address(escrowNFT), largeUnderlying);
+        escrowNFT.endEscrow(escrowId, largeUnderlying / 2);
         vm.expectRevert("escrow: already released");
         escrowNFT.endEscrow(escrowId, 0);
         vm.expectRevert("escrow: already released");
@@ -247,7 +247,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_revert_withdrawReleased() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeAmount, largeAmount, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying, 1 ether);
 
         startHoax(supplier2);
         vm.expectRevert("escrow: not escrow owner");
@@ -258,8 +258,8 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
         escrowNFT.withdrawReleased(escrowId);
 
         startHoax(loans);
-        asset.approve(address(escrowNFT), largeAmount);
-        escrowNFT.endEscrow(escrowId, largeAmount);
+        asset.approve(address(escrowNFT), largeUnderlying);
+        escrowNFT.endEscrow(escrowId, largeUnderlying);
 
         startHoax(supplier1);
         escrowNFT.transferFrom(supplier1, supplier2, escrowId);
@@ -273,7 +273,7 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
     }
 
     function test_revert_lastResortSeizeEscrow() public {
-        (uint escrowId,) = createAndCheckEscrow(supplier1, largeAmount, largeAmount / 2, 1 ether);
+        (uint escrowId,) = createAndCheckEscrow(supplier1, largeUnderlying, largeUnderlying / 2, 1 ether);
 
         startHoax(supplier2);
         vm.expectRevert("escrow: not escrow owner");
@@ -286,8 +286,8 @@ contract EscrowSupplierNFT_BasicRevertsTest is BaseEscrowSupplierNFTTest {
 
         // release
         startHoax(loans);
-        asset.approve(address(escrowNFT), largeAmount);
-        escrowNFT.endEscrow(escrowId, largeAmount / 2);
+        asset.approve(address(escrowNFT), largeUnderlying);
+        escrowNFT.endEscrow(escrowId, largeUnderlying / 2);
 
         skip(1);
         startHoax(supplier1);

--- a/test/unit/Loans.basic.effects.t.sol
+++ b/test/unit/Loans.basic.effects.t.sol
@@ -89,7 +89,7 @@ contract LoansTestBase is BaseAssetPairTestSetup {
     }
 
     function prepareDefaultSwapToUnderlying() public returns (uint swapOut) {
-        swapOut = underlyingAmount * 1e18 / oraclePrice;
+        swapOut = underlyingAmount * pow10(cashDecimals) / oraclePrice;
         prepareSwap(underlying, swapOut);
     }
 
@@ -116,17 +116,17 @@ contract LoansTestBase is BaseAssetPairTestSetup {
 
     function createProviderOffer() internal returns (uint offerId) {
         startHoax(provider);
-        cashAsset.approve(address(providerNFT), largeAmount);
-        offerId = providerNFT.createOffer(callStrikePercent, largeAmount, ltv, duration, 0);
+        cashAsset.approve(address(providerNFT), largeCash);
+        offerId = providerNFT.createOffer(callStrikePercent, largeCash, ltv, duration, 0);
     }
 
     function maybeCreateEscrowOffer() internal {
         // calculates values for with or without escrow mode
         if (openEscrowLoan) {
             startHoax(supplier);
-            underlying.approve(address(escrowNFT), largeAmount);
+            underlying.approve(address(escrowNFT), largeUnderlying);
             escrowOfferId =
-                escrowNFT.createOffer(largeAmount, duration, interestAPR, maxGracePeriod, lateFeeAPR, 0);
+                escrowNFT.createOffer(largeUnderlying, duration, interestAPR, maxGracePeriod, lateFeeAPR, 0);
             escrowFee = escrowNFT.interestFee(escrowOfferId, underlyingAmount);
         } else {
             // reset to 0

--- a/test/unit/Loans.escrow.effects.t.sol
+++ b/test/unit/Loans.escrow.effects.t.sol
@@ -231,10 +231,10 @@ contract LoansEscrowEffectsTest is LoansBasicEffectsTest {
         checkForecloseLoan(1, 1, maxGracePeriod, supplier);
 
         // price increase, and decrease
-        checkForecloseLoan(largeAmount, 1, maxGracePeriod, supplier);
+        checkForecloseLoan(largeCash, 1, maxGracePeriod, supplier);
 
         // price decrease, and increase
-        checkForecloseLoan(1, largeAmount, maxGracePeriod, supplier);
+        checkForecloseLoan(1, largeCash, maxGracePeriod, supplier);
     }
 
     function test_forecloseLoan_zero_amount_swap() public {

--- a/test/unit/Loans.escrow.effects.t.sol
+++ b/test/unit/Loans.escrow.effects.t.sol
@@ -88,7 +88,7 @@ contract LoansEscrowEffectsTest is LoansBasicEffectsTest {
 
     // repeat all effects tests (open, close, unwrap) from super, but with escrow
 
-    function test_unwrapAndCancelLoan_releasedEscrow() public {
+    function test_unwrapAndCancelLoan_after_lastResortSeizeEscrow() public {
         (uint loanId,,) = createAndCheckLoan();
 
         // check that escrow unreleased
@@ -96,7 +96,7 @@ contract LoansEscrowEffectsTest is LoansBasicEffectsTest {
         assertFalse(escrowNFT.getEscrow(escrowId).released);
 
         // after expiry
-        skip(duration + 1);
+        skip(duration + maxGracePeriod + 1);
 
         // cannot release
         vm.expectRevert("loans: loan expired");
@@ -106,10 +106,9 @@ contract LoansEscrowEffectsTest is LoansBasicEffectsTest {
         uint userBalance = underlying.balanceOf(user1);
         uint loansBalance = underlying.balanceOf(address(loans));
 
-        // release escrow via some other way without closing the loan
-        // can be lastResortSeizeEscrow if after full grace period
-        vm.startPrank(address(loans));
-        escrowNFT.endEscrow(escrowId, 0);
+        // release escrow via lastResortSeizeEscrow
+        vm.startPrank(supplier);
+        escrowNFT.lastResortSeizeEscrow(escrowId);
         assertTrue(escrowNFT.getEscrow(escrowId).released);
 
         // now can unwrap

--- a/test/unit/Loans.rolls.effects.t.sol
+++ b/test/unit/Loans.rolls.effects.t.sol
@@ -65,7 +65,7 @@ contract LoansRollTestBase is LoansTestBase {
         providerNFT.approve(address(rolls), providerId);
         cashAsset.approve(address(rolls), type(uint).max);
         rollId = rolls.createOffer(
-            takerId, rollFee, 0, 0, type(uint).max, -int(largeAmount), block.timestamp + duration
+            takerId, rollFee, 0, 0, type(uint).max, -int(largeCash), block.timestamp + duration
         );
     }
 
@@ -230,9 +230,9 @@ contract LoansRollsEffectsTest is LoansRollTestBase {
         uint newPrice = oraclePrice * 105 / 100;
         (uint newLoanId, ExpectedRoll memory expected) = checkRollLoan(loanId, newPrice);
 
-        assertEq(expected.newTakerLocked, 105 ether); // scaled by price
-        assertEq(expected.newProviderLocked, 210 ether); // scaled by price
-        assertEq(expected.toTaker, 44 ether); // 45 (+5% * 90% LTV) - 1 (fee)
+        assertEq(expected.newTakerLocked, cashUnits(105)); // scaled by price
+        assertEq(expected.newProviderLocked, cashUnits(210)); // scaled by price
+        assertEq(expected.toTaker, int(cashUnits(44))); // 45 (+5% * 90% LTV) - 1 (fee)
 
         // LTV & underlying relationship maintained (because within collar bounds)
         assertEq(underlyingAmount * newPrice * ltv / 1e18 / BIPS_100PCT, expected.newLoanAmount);
@@ -247,9 +247,9 @@ contract LoansRollsEffectsTest is LoansRollTestBase {
         uint newPrice = oraclePrice * 95 / 100;
         (uint newLoanId, ExpectedRoll memory expected) = checkRollLoan(loanId, newPrice);
 
-        assertEq(expected.newTakerLocked, 95 ether); // scaled by price
-        assertEq(expected.newProviderLocked, 190 ether); // scaled by price
-        assertEq(expected.toTaker, -46 ether); // -45 (-5% * 90% LTV) - 1 (fee)
+        assertEq(expected.newTakerLocked, cashUnits(95)); // scaled by price
+        assertEq(expected.newProviderLocked, cashUnits(190)); // scaled by price
+        assertEq(expected.toTaker, -int(cashUnits(46))); // -45 (-5% * 90% LTV) - 1 (fee)
 
         // LTV & underlying relationship maintained (because within collar bounds)
         assertEq(underlyingAmount * newPrice * ltv / 1e18 / BIPS_100PCT, expected.newLoanAmount);
@@ -264,9 +264,9 @@ contract LoansRollsEffectsTest is LoansRollTestBase {
         uint newPrice = oraclePrice * 150 / 100;
         (uint newLoanId, ExpectedRoll memory expected) = checkRollLoan(loanId, newPrice);
 
-        assertEq(expected.newTakerLocked, 150 ether); // scaled by price
-        assertEq(expected.newProviderLocked, 300 ether); // scaled by price
-        assertEq(expected.toTaker, 149 ether); // 150 (300 collar settle - 150 collar open) - 1 fee
+        assertEq(expected.newTakerLocked, cashUnits(150)); // scaled by price
+        assertEq(expected.newProviderLocked, cashUnits(300)); // scaled by price
+        assertEq(expected.toTaker, int(cashUnits(149))); // 150 (300 collar settle - 150 collar open) - 1 fee
 
         // LTV & underlying relationship NOT maintained because outside of collar bounds
         assertTrue(expected.newLoanAmount < underlyingAmount * newPrice * ltv / 1e18 / BIPS_100PCT);
@@ -281,9 +281,9 @@ contract LoansRollsEffectsTest is LoansRollTestBase {
         uint newPrice = oraclePrice * 50 / 100;
         (uint newLoanId, ExpectedRoll memory expected) = checkRollLoan(loanId, newPrice);
 
-        assertEq(expected.newTakerLocked, 50 ether); // scaled by price
-        assertEq(expected.newProviderLocked, 100 ether); // scaled by price
-        assertEq(expected.toTaker, -51 ether); // -50 (0 collar settle - 50 collar open) - 1 fee
+        assertEq(expected.newTakerLocked, cashUnits(50)); // scaled by price
+        assertEq(expected.newProviderLocked, cashUnits(100)); // scaled by price
+        assertEq(expected.toTaker, -int(cashUnits(51))); // -50 (0 collar settle - 50 collar open) - 1 fee
 
         // LTV & underlying relationship NOT maintained because outside of collar bounds
         assertTrue(expected.newLoanAmount > underlyingAmount * newPrice * ltv / 1e18 / BIPS_100PCT);

--- a/test/unit/Rolls.t.sol
+++ b/test/unit/Rolls.t.sol
@@ -16,7 +16,7 @@ contract RollsTest is BaseAssetPairTestSetup {
     uint providerLocked = swapCashAmount * (callStrikePercent - BIPS_100PCT) / BIPS_100PCT; // 100
 
     // roll offer params
-    int feeAmount = 1 ether;
+    int feeAmount = int(cashUnits(1));
     int feeDeltaFactorBIPS = 5000; // 50%
     uint minPrice = oraclePrice * 9 / 10;
     uint maxPrice = oraclePrice * 11 / 10;
@@ -25,11 +25,11 @@ contract RollsTest is BaseAssetPairTestSetup {
 
     function createProviderOffers() internal returns (uint offerId, uint offerId2) {
         startHoax(provider);
-        cashAsset.approve(address(providerNFT), largeAmount);
-        offerId = providerNFT.createOffer(callStrikePercent, largeAmount, ltv, duration, 0);
+        cashAsset.approve(address(providerNFT), largeCash);
+        offerId = providerNFT.createOffer(callStrikePercent, largeCash, ltv, duration, 0);
         // another provider NFT
-        cashAsset.approve(address(providerNFT2), largeAmount);
-        offerId2 = providerNFT2.createOffer(callStrikePercent, largeAmount, ltv, duration, 0);
+        cashAsset.approve(address(providerNFT2), largeCash);
+        offerId2 = providerNFT2.createOffer(callStrikePercent, largeCash, ltv, duration, 0);
     }
 
     function createTakerPositions() internal returns (uint takerId, uint providerId) {
@@ -307,8 +307,8 @@ contract RollsTest is BaseAssetPairTestSetup {
         - start 1000 at price 1000, 100 user locked, 200 provider locked
         - no changes except fee being charged
         */
-        assertEq(expected.newTakerLocked, 100 ether);
-        assertEq(expected.newProviderLocked, 200 ether);
+        assertEq(expected.newTakerLocked, cashUnits(100));
+        assertEq(expected.newProviderLocked, cashUnits(200));
         assertEq(expected.toTaker, -expected.rollFee);
         assertEq(expected.toProvider, expected.rollFee - int(expected.toProtocol));
     }
@@ -321,8 +321,8 @@ contract RollsTest is BaseAssetPairTestSetup {
         - start 1000 at price 1000, 100 user locked, 200 provider locked
         - no changes except fee being charged
         */
-        assertEq(expected.newTakerLocked, 100 ether);
-        assertEq(expected.newProviderLocked, 200 ether);
+        assertEq(expected.newTakerLocked, cashUnits(100));
+        assertEq(expected.newProviderLocked, cashUnits(200));
         assertEq(expected.toTaker, 0);
         assertEq(expected.toProvider, -int(expected.toProtocol));
     }
@@ -339,10 +339,10 @@ contract RollsTest is BaseAssetPairTestSetup {
         - toTaker = 150 - 105 = 45
         - toProvider = 150 - 210 = -60
         */
-        assertEq(expected.newTakerLocked, 105 ether);
-        assertEq(expected.newProviderLocked, 210 ether);
-        assertEq(expected.toTaker, 45 ether - expected.rollFee);
-        assertEq(expected.toProvider, -60 ether + expected.rollFee - int(expected.toProtocol));
+        assertEq(expected.newTakerLocked, cashUnits(105));
+        assertEq(expected.newProviderLocked, cashUnits(210));
+        assertEq(expected.toTaker, int(cashUnits(45)) - expected.rollFee);
+        assertEq(expected.toProvider, -int(cashUnits(60)) + expected.rollFee - int(expected.toProtocol));
     }
 
     function test_executeRoll_5_pct_down_simple() public {
@@ -357,16 +357,16 @@ contract RollsTest is BaseAssetPairTestSetup {
         - toTaker = 50 - 95 = -45
         - toProvider = 250 - 190 = 60
         */
-        assertEq(expected.newTakerLocked, 95 ether);
-        assertEq(expected.newProviderLocked, 190 ether);
-        assertEq(expected.toTaker, -45 ether - expected.rollFee);
-        assertEq(expected.toProvider, 60 ether + expected.rollFee - int(expected.toProtocol));
+        assertEq(expected.newTakerLocked, cashUnits(95));
+        assertEq(expected.newProviderLocked, cashUnits(190));
+        assertEq(expected.toTaker, -int(cashUnits(45)) - expected.rollFee);
+        assertEq(expected.toProvider, int(cashUnits(60)) + expected.rollFee - int(expected.toProtocol));
     }
 
     function test_executeRoll_30_pct_up_simple() public {
         // increase price tolerance
         maxPrice = oraclePrice * 2;
-        minToProvider = -260 ether;
+        minToProvider = -int(cashUnits(260));
         // Move the price up by 30%
         ExpectedRoll memory expected = checkExecuteRollForPriceChange(oraclePrice * 130 / 100);
 
@@ -378,10 +378,10 @@ contract RollsTest is BaseAssetPairTestSetup {
         - toTaker = 300 - 130 = 170
         - toProvider = 0 - 260 = -260
         */
-        assertEq(expected.newTakerLocked, 130 ether);
-        assertEq(expected.newProviderLocked, 260 ether);
-        assertEq(expected.toTaker, 170 ether - expected.rollFee);
-        assertEq(expected.toProvider, -260 ether + expected.rollFee - int(expected.toProtocol));
+        assertEq(expected.newTakerLocked, cashUnits(130));
+        assertEq(expected.newProviderLocked, cashUnits(260));
+        assertEq(expected.toTaker, int(cashUnits(170)) - expected.rollFee);
+        assertEq(expected.toProvider, -int(cashUnits(260)) + expected.rollFee - int(expected.toProtocol));
     }
 
     function test_executeRoll_20_pct_down_simple() public {
@@ -398,10 +398,10 @@ contract RollsTest is BaseAssetPairTestSetup {
         - toTaker = 0 - 80 = -80
         - toProvider = 300 - 160 = 140
         */
-        assertEq(expected.newTakerLocked, 80 ether);
-        assertEq(expected.newProviderLocked, 160 ether);
-        assertEq(expected.toTaker, -80 ether - expected.rollFee);
-        assertEq(expected.toProvider, 140 ether + expected.rollFee - int(expected.toProtocol));
+        assertEq(expected.newTakerLocked, cashUnits(80));
+        assertEq(expected.newProviderLocked, cashUnits(160));
+        assertEq(expected.toTaker, -int(cashUnits(80)) - expected.rollFee);
+        assertEq(expected.toProvider, int(cashUnits(140)) + expected.rollFee - int(expected.toProtocol));
     }
 
     function test_calculateRollFee() public {
@@ -412,79 +412,79 @@ contract RollsTest is BaseAssetPairTestSetup {
 
         // Price increase, positive fee, positive delta factor
         uint newPrice = oraclePrice * 110 / 100; // 10% increase
-        // Expected: 1 ether + (1 ether * 50% * 10%) = 1.05 ether
-        assertEq(rolls.calculateRollFee(offer, newPrice), 1.05 ether, "f+ p+ d+");
+        // Expected: 1 + (1 * 50% * 10%) = 1.05
+        assertEq(rolls.calculateRollFee(offer, newPrice), int(cashFraction(1.05 ether)), "f+ p+ d+");
 
         // Price increase, positive fee, negative delta factor
-        offer.feeAmount = 1 ether;
+        offer.feeAmount = int(cashUnits(1));
         offer.feeDeltaFactorBIPS = -5000; // -50%
         newPrice = oraclePrice * 110 / 100;
-        // Expected: 1 ether - (1 ether * 50% * 10%) = 0.95 ether
-        assertEq(rolls.calculateRollFee(offer, newPrice), 0.95 ether, "f+ p+ d-");
+        // Expected: 1 - (1 * 50% * 10%) = 0.95
+        assertEq(rolls.calculateRollFee(offer, newPrice), int(cashFraction(0.95 ether)), "f+ p+ d-");
 
         // Price decrease, positive fee, negative delta factor
         newPrice = oraclePrice * 90 / 100; // 10% decrease
         offer.feeDeltaFactorBIPS = -5000;
-        // Expected: 1 ether + (1 ether * 50% * 10%) = 1.05 ether
-        assertEq(rolls.calculateRollFee(offer, newPrice), 1.05 ether, "f+ p- d-");
+        // Expected: 1 + (1 * 50% * 10%) = 1.05
+        assertEq(rolls.calculateRollFee(offer, newPrice), int(cashFraction(1.05 ether)), "f+ p- d-");
 
         // Price decrease, positive fee, positive delta factor
         newPrice = oraclePrice * 90 / 100; // 10% decrease
         offer.feeDeltaFactorBIPS = 5000;
-        // Expected: 1 ether - (1 ether * 50% * 10%) = 0.95 ether
-        assertEq(rolls.calculateRollFee(offer, newPrice), 0.95 ether, "f+ p- d+");
+        // Expected: 1 - (1  * 50% * 10%) = 0.95
+        assertEq(rolls.calculateRollFee(offer, newPrice), int(cashFraction(0.95 ether)), "f+ p- d+");
 
         // Price increase, negative fee, positive delta factor
-        offer.feeAmount = -1 ether;
+        offer.feeAmount = -int(cashUnits(1));
         newPrice = oraclePrice * 110 / 100;
-        // Expected: -1 ether + (1 ether * 50% * 10%) = -0.95 ether
-        assertEq(rolls.calculateRollFee(offer, newPrice), -0.95 ether, "f- p+ d+");
+        // Expected: -1 + (1 * 50% * 10%) = -0.95
+        assertEq(rolls.calculateRollFee(offer, newPrice), -int(cashFraction(0.95 ether)), "f- p+ d+");
 
         // Price increase, negative fee, positive delta factor
-        offer.feeAmount = -1 ether;
+        offer.feeAmount = -int(cashUnits(1));
         newPrice = oraclePrice * 110 / 100;
         offer.feeDeltaFactorBIPS = -5000;
-        // Expected: -1 ether - (1 ether * 50% * 10%) = -1.05 ether
-        assertEq(rolls.calculateRollFee(offer, newPrice), -1.05 ether, "f- p+ d-");
+        // Expected: -1 - (1 * 50% * 10%) = -1.05
+        assertEq(rolls.calculateRollFee(offer, newPrice), -int(cashFraction(1.05 ether)), "f- p+ d-");
 
         // Price decrease, negative fee, negative delta factor
-        offer.feeAmount = -1 ether;
+        offer.feeAmount = -int(cashUnits(1));
         newPrice = oraclePrice * 90 / 100; // 10% decrease
         offer.feeDeltaFactorBIPS = 5000;
-        // Expected: -1 ether - (1 ether * 50% * 10%) = -1.05 ether
-        assertEq(rolls.calculateRollFee(offer, newPrice), -1.05 ether, "f- p- d+");
+        // Expected: -1 - (1 * 50% * 10%) = -1.05
+        assertEq(rolls.calculateRollFee(offer, newPrice), -int(cashFraction(1.05 ether)), "f- p- d+");
 
         // Price decrease, negative fee, negative delta factor
-        offer.feeAmount = -1 ether;
+        offer.feeAmount = -int(cashUnits(1));
         newPrice = oraclePrice * 90 / 100; // 10% decrease
         offer.feeDeltaFactorBIPS = -5000;
-        // Expected: -1 ether + (1 ether * 50% * 10%) = -0.95 ether
-        assertEq(rolls.calculateRollFee(offer, newPrice), -0.95 ether, "f- p- d-");
+        // Expected: -1 + (1 * 50% * 10%) = -0.95
+        assertEq(rolls.calculateRollFee(offer, newPrice), -int(cashFraction(0.95 ether)), "f- p- d-");
 
         // Large price change (100% increase)
-        offer.feeAmount = 1 ether;
+        offer.feeAmount = int(cashUnits(1));
         newPrice = oraclePrice * 200 / 100;
         offer.feeDeltaFactorBIPS = 5000; // 50%
-        // Expected: 1 ether + (1 ether * 50% * 100%) = 1.5 ether
-        assertEq(rolls.calculateRollFee(offer, newPrice), 1.5 ether, "+100%");
+        // Expected: 1 + (1 * 50% * 100%) = 1.5
+        assertEq(rolls.calculateRollFee(offer, newPrice), int(cashFraction(1.5 ether)), "+100%");
 
         // Zero fee
         offer.feeAmount = 0;
         assertEq(rolls.calculateRollFee(offer, oraclePrice * 150 / 100), 0, "0 fee");
 
         // Test case 9: Zero delta factor
-        offer.feeAmount = 1 ether;
+        offer.feeAmount = int(cashUnits(1));
         offer.feeDeltaFactorBIPS = 0;
-        assertEq(rolls.calculateRollFee(offer, oraclePrice * 150 / 100), 1 ether, "0 delta");
+        assertEq(rolls.calculateRollFee(offer, oraclePrice * 150 / 100), int(cashUnits(1)), "0 delta");
     }
 
     function test_calculateRollFee_additional() public {
         (,, IRolls.RollOffer memory offer) = createAndCheckRollOffer();
 
         // Edge cases for price changes
-        assertEq(rolls.calculateRollFee(offer, 0), 0.5 ether, "-100% price");
+        assertEq(rolls.calculateRollFee(offer, 0), int(cashFraction(0.5 ether)), "-100% price");
 
-        assertEq(rolls.calculateRollFee(offer, oraclePrice * 2), 1.5 ether, "+100%");
+        assertEq(rolls.calculateRollFee(offer, oraclePrice * 2), int(cashFraction(1.5 ether)), "+100%");
 
         // Edge cases for fee amounts
         offer.feeAmount = type(int).min;
@@ -496,16 +496,22 @@ contract RollsTest is BaseAssetPairTestSetup {
         rolls.calculateRollFee(offer, oraclePrice * 110 / 100);
 
         // Edge cases for delta factors
-        offer.feeAmount = 1 ether;
+        offer.feeAmount = int(cashUnits(1));
         offer.feeDeltaFactorBIPS = 10_000; // 100%
         assertEq(rolls.calculateRollFee(offer, 0), 0, "full delta factor no fee");
 
         offer.feeDeltaFactorBIPS = 10_000; // 100%
-        assertEq(rolls.calculateRollFee(offer, oraclePrice * 110 / 100), 1.1 ether, "linear fee");
+        assertEq(
+            rolls.calculateRollFee(offer, oraclePrice * 110 / 100), int(cashFraction(1.1 ether)), "linear fee"
+        );
 
         // Precision check
         offer.feeDeltaFactorBIPS = 10_000; // 100%
-        assertGt(rolls.calculateRollFee(offer, 10_001 * oraclePrice / 10_000), 1 ether, "tiny price change");
+        assertGt(
+            rolls.calculateRollFee(offer, 10_001 * oraclePrice / 10_000),
+            int(cashUnits(1)),
+            "tiny price change"
+        );
     }
 
     function test_pause() public {

--- a/test/unit/SwapperUniV3Direct.mocks.t.sol
+++ b/test/unit/SwapperUniV3Direct.mocks.t.sol
@@ -26,8 +26,8 @@ contract SwapperUniV3Test is Test {
         mockRouter = new MockSwapperRouter();
         swapper = new SwapperUniV3(address(mockRouter), feeTier);
 
-        tokenIn = new TestERC20("Mock Token In", "MTI");
-        tokenOut = new TestERC20("Mock Token Out", "MTO");
+        tokenIn = new TestERC20("Mock Token In", "MTI", 18);
+        tokenOut = new TestERC20("Mock Token Out", "MTO", 18);
     }
 
     function setupSwap(uint _amountIn, uint _amountOut) internal {

--- a/test/utils/TestERC20.sol
+++ b/test/utils/TestERC20.sol
@@ -6,10 +6,17 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 contract TestERC20 is ERC20 {
     // reentrancy attacker
     address public attacker;
+    uint8 internal _decimals;
 
     mapping(address to => bool blocked) public blockList;
 
-    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) { }
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) ERC20(name_, symbol_) {
+        _decimals = decimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
 
     function mint(address to, uint amount) external {
         _mint(to, amount);


### PR DESCRIPTION
A few test improvements:
- use non 18 decimals cash asset and CL feed in unit tests and separate cash and underlying amounts
- fix the fuzz test for calc such that precision rounding issue can be shown
- make cancel escrow test for seize escrow more specific
- handle previously commented out fork tests (revive two, remove the other ones)
- add assertions to ensure all deployed pairs are tested