### PR TITLE
Opbase add cbBTC

### DIFF
--- a/script/utils/Const.sol
+++ b/script/utils/Const.sol
@@ -69,6 +69,7 @@ library Const {
     // https://docs.chain.link/data-feeds/price-feeds/addresses?network=base&page=1
     address internal constant OPBaseMain_CLFeedETH_USD = 0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70; // 0.15%, 1200, 8
     address internal constant OPBaseMain_CLFeedUSDC_USD = 0x7e860098F58bBFC8648a4311b374B1D669a2bc6B; // 0.3%, 86400, 8
+    address internal constant OPBaseMain_CLFeedCBBTC_USD = 0x07DA0E54543a844a80ABE69c8A12F22B3aA59f9D; // 0.3%, 1200, 8
     address internal constant OPBaseSep_CLFeedETH_USD = 0x4aDC67696bA383F43DD60A9e78F2C97Fbbfc7cb1; // 0.15%, 1200, 8
     address internal constant OPBaseSep_CLFeedUSDC_USD = 0xd30e2101a97dcbAeBCBC04F14C3f624E67A35165; // 0.1%, 86400, 8
 
@@ -76,6 +77,7 @@ library Const {
     // https://app.uniswap.org/explore/pools/base/
     address internal constant OPBaseMain_USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
     address internal constant OPBaseMain_WETH = 0x4200000000000000000000000000000000000006;
+    address internal constant OPBaseMain_cbBTC = 0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf;
     address internal constant OPBaseSep_USDC = 0xf7464321dE37BdE4C03AAeeF6b1e7b71379A9a64;
     address internal constant OPBaseSep_WETH = 0x4200000000000000000000000000000000000006;
     address internal constant OPBaseSep_tUSDC = address(0); // TBD

--- a/test/integration/ChainlinkOracle.forks.t.sol
+++ b/test/integration/ChainlinkOracle.forks.t.sol
@@ -262,6 +262,19 @@ contract ChainlinkOracle_OPBaseMain_WETHUSDC_ForkTest is ChainlinkOracle_ArbiMai
     }
 }
 
+contract ChainlinkOracle_OPBaseMain_CBBTCUSDC_ForkTest is ChainlinkOracle_OPBaseMain_WETHUSDC_ForkTest {
+    function _config() internal virtual override {
+        super._config();
+        baseToken = Const.OPBaseMain_cbBTC;
+        priceFeed = Const.OPBaseMain_CLFeedCBBTC_USD;
+        description = "cbBTC / USD";
+
+        expectedAnswer = 10_190_410_180_039; // 8 decimals
+        expectedCurPrice = 101_904_101_800; // 6 decimals
+        expectedInversePrice = 981; // 1e8 * 1e8 / 10_190_410_180_039
+    }
+}
+
 contract ChainlinkOracle_OPBaseSep_WETHUSDC_ForkTest is ChainlinkOracle_ArbiMain_WETHUSDC_ForkTest {
     function _startFork() internal override {
         vm.createSelectFork(vm.envString("OPBASE_SEPOLIA_RPC"), 21_176_690);

--- a/test/integration/full-protocol/Loans.pairs.fork.t.sol
+++ b/test/integration/full-protocol/Loans.pairs.fork.t.sol
@@ -213,6 +213,14 @@ contract WETHUSDC_ArbiSep_LoansForkTest_noExport is WETHUSDC_ArbiSep_LoansForkTe
     }
 }
 
+contract WBTCUSDC_ArbiSep_LoansForkTest_noExport is WBTCUSDC_ArbiSep_LoansForkTest {
+    function setUp() public override {
+        // do not use the artifacts for this test (only the direct deployment result)
+        loadFromArtifacts = false;
+        super.setUp();
+    }
+}
+
 ////// load existing sepolia deployment
 contract WETHUSDC_ArbiSep_LoansForkTest_NoDeploy is ArbiSep_LoansForkTest_LatestBlock {
     function getDeployedContracts()
@@ -221,7 +229,17 @@ contract WETHUSDC_ArbiSep_LoansForkTest_NoDeploy is ArbiSep_LoansForkTest_Latest
         returns (ConfigHub hub, BaseDeployer.AssetPairContracts[] memory pairs)
     {
         setupNewFork();
+        return DeploymentArtifactsLib.loadHubAndAllPairs(vm, Const.ArbiSep_artifactsName);
+    }
+}
 
+contract WBTCUSDC_ArbiSep_LoansForkTest_NoDeploy is WBTCUSDC_ArbiSep_LoansForkTest {
+    function getDeployedContracts()
+        internal
+        override
+        returns (ConfigHub hub, BaseDeployer.AssetPairContracts[] memory pairs)
+    {
+        setupNewFork();
         return DeploymentArtifactsLib.loadHubAndAllPairs(vm, Const.ArbiSep_artifactsName);
     }
 }
@@ -257,7 +275,7 @@ contract WETHUSDC_OPBaseMain_LoansForkTest is BaseAssetPairForkTest_ScriptTest {
         pauseGuardians.push(Const.OPBaseMain_deployerAcc);
 
         // @dev all pairs must be tested, so if this number is increased, test classes must be added
-        expectedNumPairs = 1;
+        expectedNumPairs = 2;
 
         // set up all the variables for this pair
         expectedPairIndex = 0;
@@ -278,6 +296,26 @@ contract WETHUSDC_OPBaseMain_LoansForkTest is BaseAssetPairForkTest_ScriptTest {
         callstrikeToUse = 11_000;
 
         expectedOraclePrice = 3_000_000_000;
+    }
+}
+
+contract CBBTCUSDC_OPBaseMain_LoansForkTest is WETHUSDC_OPBaseMain_LoansForkTest {
+    function _setTestValues() internal virtual override {
+        super._setTestValues();
+
+        // @dev all pairs must be tested, so if this number is increased, test classes must be added
+        expectedNumPairs = 2;
+
+        // set up all the variables for this pair
+        expectedPairIndex = 1;
+        underlying = Const.OPBaseMain_cbBTC;
+        cashAsset = Const.OPBaseMain_USDC;
+        oracleDescription = "Comb(CL(cbBTC / USD)|inv(CL(USDC / USD)))";
+
+        underlyingAmount = 0.1e8;
+        bigUnderlyingAmount = 100e8;
+
+        expectedOraclePrice = 90_000_000_000;
     }
 }
 


### PR DESCRIPTION
- Add cbBTC to OPBase deployer and the related fork tests.
- Add some of missing Arbi-Sep WBTC fork tests variants