### PR TITLE
Protocol fee update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Notable changes to contracts will be noted here
+Notable changes to contracts.
 
 # Unreleased
 
@@ -9,6 +9,6 @@ Notable changes to contracts will be noted here
 - Rolls:
   - Update to use the updated protocolFee interface.
 
-# 0.2.0 all
+# 0.2.0 (All contracts)
 
 First version deployed to Base mainnet. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+Notable changes to contracts will be noted here
+
+# Unreleased
+
+- CollarProviderNFT:
+  - `protocolFee` charges fee on full notional amount (cash value of loan input), and expects `callStrikePercent` argument.
+- Rolls:
+  - Update to use the updated protocolFee interface.
+
+# 0.2.0 all
+
+First version deployed to Base mainnet. 

--- a/src/Rolls.sol
+++ b/src/Rolls.sol
@@ -398,7 +398,8 @@ contract Rolls is IRolls, BaseManaged {
         (uint newTakerLocked, uint newProviderLocked) = _newLockedAmounts(takerPos, newPrice);
 
         // new protocol fee. @dev there is no refund for previously paid protocol fee
-        (uint protocolFee,) = takerPos.providerNFT.protocolFee(newProviderLocked, takerPos.duration);
+        (uint protocolFee,) =
+            takerPos.providerNFT.protocolFee(newProviderLocked, takerPos.duration, takerPos.callStrikePercent);
 
         // The taker and provider external balances (before fee) should be updated as if
         // they settled and withdrawn the old positions, and opened the new positions.

--- a/test/integration/full-protocol/BaseAssetPairForkTest.sol
+++ b/test/integration/full-protocol/BaseAssetPairForkTest.sol
@@ -319,7 +319,7 @@ abstract contract BaseAssetPairForkTest is Test {
         // Calculate protocol fee based on post-swap provider locked amount
         uint swapOut = loanAmount * BIPS_BASE / ltv;
         uint initProviderLocked = swapOut * (callstrikeToUse - BIPS_BASE) / BIPS_BASE;
-        (protocolFee,) = pair.providerNFT.protocolFee(initProviderLocked, duration);
+        (protocolFee,) = pair.providerNFT.protocolFee(initProviderLocked, duration, callstrikeToUse);
         assertGt(protocolFee, 0);
     }
 

--- a/test/unit/Loans.basic.effects.t.sol
+++ b/test/unit/Loans.basic.effects.t.sol
@@ -182,7 +182,7 @@ contract LoansTestBase is BaseAssetPairTestSetup {
 
         uint expectedLoanAmount = swapOut * ltv / BIPS_100PCT;
         uint expectedProviderLocked = swapOut * (callStrikePercent - BIPS_100PCT) / BIPS_100PCT;
-        (uint expectedProtocolFee,) = providerNFT.protocolFee(expectedProviderLocked, duration);
+        (uint expectedProtocolFee,) = providerNFT.protocolFee(expectedProviderLocked, duration, callStrikePercent);
         if (expectedProviderLocked != 0) assertGt(expectedProtocolFee, 0); // ensure fee is expected
 
         ILoansNFT.SwapParams memory swapParams = defaultSwapParams(swapCashAmount);

--- a/test/unit/Rolls.t.sol
+++ b/test/unit/Rolls.t.sol
@@ -131,7 +131,7 @@ contract RollsTest is BaseAssetPairTestSetup {
             takerNFT.calculateProviderLocked(expected.newTakerLocked, ltv, callStrikePercent)
         );
         // protocol fee
-        (expected.toProtocol,) = providerNFT.protocolFee(expected.newProviderLocked, duration);
+        (expected.toProtocol,) = providerNFT.protocolFee(expected.newProviderLocked, duration, callStrikePercent);
         // _calculateTransferAmounts
         (uint takerSettled, int providerChange) = takerNFT.previewSettlement(oldTakerPos, newPrice);
         int providerSettled = int(oldTakerPos.providerLocked) + providerChange;


### PR DESCRIPTION
Update the protocol fee to charge on full notional cash value instead of only on providerLocked amount.

:warning: the `NoDeploy` fork tests are failing, because deployed protocol fee is different from what's being expected in tests (for the updated functionality).