### PR TITLE
Ownership reduction part 1 - remove pausing and ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Notable changes to contracts will be noted here
+Notable changes to contracts.
 
 # Unreleased
 
@@ -9,6 +9,6 @@ Notable changes to contracts will be noted here
 - Rolls:
   - Update to use the updated protocolFee interface.
 
-# 0.2.0 all
+# 0.2.0 (All contracts)
 
 First version deployed to Base mainnet. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to contracts.
 
-# Unreleased
+# Unreleased (0.3.0)
 
 - BaseManaged:
   - No direct ownership, instead has `onlyConfigHubOwner` modifier.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+Notable changes to contracts will be noted here
+
+# Unreleased
+
+- CollarProviderNFT:
+  - `protocolFee` charges fee on full notional amount (cash value of loan input), and expects `callStrikePercent` argument.
+- Rolls:
+  - Update to use the updated protocolFee interface.
+
+# 0.2.0 all
+
+First version deployed to Base mainnet. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,18 @@ Notable changes to contracts.
 
 # Unreleased
 
+- BaseManaged:
+  - No direct ownership, instead has `onlyConfigHubOwner` modifier.
+  - All pausing removed.
+- CollarTakerNFT, LoansNFT, EscrowSupplierNFT, CollarProviderNFT:
+  - Inheriting from updated BaseManaged (not ownable, not pausable).
+  - Different constructor interface. 
+  - Using `onlyConfigHubOwner` for admin methods.
 - CollarProviderNFT:
   - `protocolFee` charges fee on full notional amount (cash value of loan input), and expects `callStrikePercent` argument.
 - Rolls:
   - Update to use the updated protocolFee interface.
+  - Not inheriting from BaseManaged. 
 
 # 0.2.0 (All contracts)
 

--- a/script/deploy/accept-ownership.s.sol
+++ b/script/deploy/accept-ownership.s.sol
@@ -48,7 +48,7 @@ abstract contract AcceptOwnershipScript is Script {
             DeploymentArtifactsLib.loadHubAndAllPairs(vm, artifactsName);
 
         // deploy and nominate owner
-        BaseDeployer.acceptOwnershipAsSender(owner, result.configHub, result.assetPairContracts);
+        BaseDeployer.acceptOwnershipAsSender(owner, result.configHub);
 
         vm.stopBroadcast();
     }

--- a/script/libraries/ArbitrumMainnetDeployer.sol
+++ b/script/libraries/ArbitrumMainnetDeployer.sol
@@ -39,16 +39,16 @@ library ArbitrumMainnetDeployer {
         BaseDeployer.setupConfigHub(result.configHub, defaultHubParams());
 
         // pairs
-        result.assetPairContracts = deployAllContractPairs(thisSender, result.configHub);
+        result.assetPairContracts = deployAllContractPairs(result.configHub);
         for (uint i = 0; i < result.assetPairContracts.length; i++) {
             BaseDeployer.setupContractPair(result.configHub, result.assetPairContracts[i]);
         }
 
         // ownership
-        BaseDeployer.nominateNewOwnerAll(finalOwner, result);
+        BaseDeployer.nominateNewHubOwner(finalOwner, result);
     }
 
-    function deployAllContractPairs(address initialOwner, ConfigHub configHub)
+    function deployAllContractPairs(ConfigHub configHub)
         internal
         returns (BaseDeployer.AssetPairContracts[] memory assetPairContracts)
     {
@@ -83,12 +83,10 @@ library ArbitrumMainnetDeployer {
         );
 
         // if any escrowNFT contracts will be reused for multiple pairs, they should be deployed first
-        EscrowSupplierNFT wethEscrow =
-            BaseDeployer.deployEscrowNFT(initialOwner, configHub, IERC20(WETH), "WETH");
+        EscrowSupplierNFT wethEscrow = BaseDeployer.deployEscrowNFT(configHub, IERC20(WETH), "WETH");
 
         // deploy pairs
         assetPairContracts[0] = BaseDeployer.deployContractPair(
-            initialOwner,
             configHub,
             BaseDeployer.PairConfig({
                 name: "WETH/USDC",
@@ -104,7 +102,6 @@ library ArbitrumMainnetDeployer {
         );
 
         assetPairContracts[1] = BaseDeployer.deployContractPair(
-            initialOwner,
             configHub,
             BaseDeployer.PairConfig({
                 name: "WETH/USDT",
@@ -120,7 +117,6 @@ library ArbitrumMainnetDeployer {
         );
 
         assetPairContracts[2] = BaseDeployer.deployContractPair(
-            initialOwner,
             configHub,
             BaseDeployer.PairConfig({
                 name: "WBTC/USDT",

--- a/script/libraries/ArbitrumSepoliaDeployer.sol
+++ b/script/libraries/ArbitrumSepoliaDeployer.sol
@@ -40,13 +40,13 @@ library ArbitrumSepoliaDeployer {
         BaseDeployer.setupConfigHub(result.configHub, defaultHubParams());
 
         // pairs
-        result.assetPairContracts = deployAllContractPairs(thisSender, result.configHub);
+        result.assetPairContracts = deployAllContractPairs(result.configHub);
         for (uint i = 0; i < result.assetPairContracts.length; i++) {
             BaseDeployer.setupContractPair(result.configHub, result.assetPairContracts[i]);
         }
 
         // ownership
-        BaseDeployer.nominateNewOwnerAll(finalOwner, result);
+        BaseDeployer.nominateNewHubOwner(finalOwner, result);
     }
 
     function deployMockOracleETHUSD() internal returns (BaseTakerOracle oracle) {
@@ -90,7 +90,7 @@ library ArbitrumSepoliaDeployer {
         oracle = BaseDeployer.deployChainlinkOracle(tUSDC, Const.VIRTUAL_ASSET, feedUSDC_USD, sequencerFeed);
     }
 
-    function deployAllContractPairs(address initialOwner, ConfigHub configHub)
+    function deployAllContractPairs(ConfigHub configHub)
         internal
         returns (BaseDeployer.AssetPairContracts[] memory assetPairContracts)
     {
@@ -104,7 +104,6 @@ library ArbitrumSepoliaDeployer {
 
         // if any escrowNFT contracts will be reused for multiple pairs, they should be deployed first
         assetPairContracts[0] = BaseDeployer.deployContractPair(
-            initialOwner,
             configHub,
             BaseDeployer.PairConfig({
                 name: "WETH/USDC",
@@ -125,7 +124,6 @@ library ArbitrumSepoliaDeployer {
         );
 
         assetPairContracts[1] = BaseDeployer.deployContractPair(
-            initialOwner,
             configHub,
             BaseDeployer.PairConfig({
                 name: "WBTC/USDC",

--- a/script/libraries/BaseDeployer.sol
+++ b/script/libraries/BaseDeployer.sol
@@ -66,14 +66,11 @@ library BaseDeployer {
         return new ConfigHub(initialOwner);
     }
 
-    function deployEscrowNFT(
-        address initialOwner,
-        ConfigHub configHub,
-        IERC20 underlying,
-        string memory underlyingSymbol
-    ) internal returns (EscrowSupplierNFT) {
+    function deployEscrowNFT(ConfigHub configHub, IERC20 underlying, string memory underlyingSymbol)
+        internal
+        returns (EscrowSupplierNFT)
+    {
         return new EscrowSupplierNFT(
-            initialOwner,
             configHub,
             underlying,
             string(abi.encodePacked("Escrow ", underlyingSymbol)),
@@ -116,12 +113,11 @@ library BaseDeployer {
         );
     }
 
-    function deployContractPair(address initialOwner, ConfigHub configHub, PairConfig memory pairConfig)
+    function deployContractPair(ConfigHub configHub, PairConfig memory pairConfig)
         internal
         returns (AssetPairContracts memory contracts)
     {
         CollarTakerNFT takerNFT = new CollarTakerNFT(
-            initialOwner,
             configHub,
             pairConfig.cashAsset,
             pairConfig.underlying,
@@ -130,7 +126,6 @@ library BaseDeployer {
             string.concat("T", pairConfig.name)
         );
         CollarProviderNFT providerNFT = new CollarProviderNFT(
-            initialOwner,
             configHub,
             pairConfig.cashAsset,
             pairConfig.underlying,
@@ -139,10 +134,7 @@ library BaseDeployer {
             string.concat("P", pairConfig.name)
         );
         LoansNFT loansContract = new LoansNFT(
-            initialOwner,
-            takerNFT,
-            string.concat("Loans ", pairConfig.name),
-            string.concat("L", pairConfig.name)
+            takerNFT, string.concat("Loans ", pairConfig.name), string.concat("L", pairConfig.name)
         );
         Rolls rollsContract = new Rolls(takerNFT);
         SwapperUniV3 swapperUniV3 = new SwapperUniV3(pairConfig.swapRouter, pairConfig.swapFeeTier);
@@ -152,10 +144,7 @@ library BaseDeployer {
             escrowNFT = EscrowSupplierNFT(pairConfig.existingEscrowNFT);
         } else {
             escrowNFT = deployEscrowNFT(
-                initialOwner,
-                configHub,
-                pairConfig.underlying,
-                IERC20Metadata(address(pairConfig.underlying)).symbol()
+                configHub, pairConfig.underlying, IERC20Metadata(address(pairConfig.underlying)).symbol()
             );
         }
         contracts = AssetPairContracts({
@@ -194,38 +183,16 @@ library BaseDeployer {
     }
 
     // @dev this only nominates, and ownership must be accepted by the new owner
-    function nominateNewOwnerAll(address finalOwner, DeploymentResult memory result) internal {
+    function nominateNewHubOwner(address finalOwner, DeploymentResult memory result) internal {
         result.configHub.transferOwnership(finalOwner);
-
-        for (uint i = 0; i < result.assetPairContracts.length; i++) {
-            nominateNewOwnerPair(finalOwner, result.assetPairContracts[i]);
-        }
     }
 
-    function nominateNewOwnerPair(address finalOwner, AssetPairContracts memory pair) internal {
-        pair.takerNFT.transferOwnership(finalOwner);
-        pair.providerNFT.transferOwnership(finalOwner);
-        pair.loansContract.transferOwnership(finalOwner);
-        pair.rollsContract.transferOwnership(finalOwner);
-        pair.escrowNFT.transferOwnership(finalOwner);
-    }
-
-    function acceptOwnershipAsSender(address acceptingOwner, ConfigHub hub, AssetPairContracts[] memory pairs)
-        internal
-    {
+    function acceptOwnershipAsSender(address acceptingOwner, ConfigHub hub) internal {
         // we can't ensure sender is acceptingOwner by checking here because:
         // - if this is run in a script msg.sender will be the scripts's sender
         // - if it's run from a test it will be whoever is being pranked, or the test contract
         // - if ran from within a contract, will be the contract address
         // In any case, the acceptance will not work if sender is incorrect.
         hub.acceptOwnership();
-        for (uint i = 0; i < pairs.length; i++) {
-            pairs[i].takerNFT.acceptOwnership();
-            pairs[i].providerNFT.acceptOwnership();
-            pairs[i].loansContract.acceptOwnership();
-            pairs[i].rollsContract.acceptOwnership();
-            // check because we may have already accepted previously (for another pair)
-            if (pairs[i].escrowNFT.owner() != acceptingOwner) pairs[i].escrowNFT.acceptOwnership();
-        }
     }
 }

--- a/script/libraries/BaseDeployer.sol
+++ b/script/libraries/BaseDeployer.sol
@@ -144,7 +144,7 @@ library BaseDeployer {
             string.concat("Loans ", pairConfig.name),
             string.concat("L", pairConfig.name)
         );
-        Rolls rollsContract = new Rolls(initialOwner, takerNFT);
+        Rolls rollsContract = new Rolls(takerNFT);
         SwapperUniV3 swapperUniV3 = new SwapperUniV3(pairConfig.swapRouter, pairConfig.swapFeeTier);
         // Use existing escrow if provided, otherwise create new
         EscrowSupplierNFT escrowNFT;

--- a/script/libraries/OPBaseMainnetDeployer.sol
+++ b/script/libraries/OPBaseMainnetDeployer.sol
@@ -37,16 +37,16 @@ library OPBaseMainnetDeployer {
         BaseDeployer.setupConfigHub(result.configHub, defaultHubParams());
 
         // pairs
-        result.assetPairContracts = deployAllContractPairs(thisSender, result.configHub);
+        result.assetPairContracts = deployAllContractPairs(result.configHub);
         for (uint i = 0; i < result.assetPairContracts.length; i++) {
             BaseDeployer.setupContractPair(result.configHub, result.assetPairContracts[i]);
         }
 
         // ownership
-        BaseDeployer.nominateNewOwnerAll(finalOwner, result);
+        BaseDeployer.nominateNewHubOwner(finalOwner, result);
     }
 
-    function deployAllContractPairs(address initialOwner, ConfigHub configHub)
+    function deployAllContractPairs(ConfigHub configHub)
         internal
         returns (BaseDeployer.AssetPairContracts[] memory assetPairContracts)
     {
@@ -76,7 +76,6 @@ library OPBaseMainnetDeployer {
 
         // deploy pairs
         assetPairContracts[0] = BaseDeployer.deployContractPair(
-            initialOwner,
             configHub,
             BaseDeployer.PairConfig({
                 name: "WETH/USDC",
@@ -92,7 +91,6 @@ library OPBaseMainnetDeployer {
         );
 
         assetPairContracts[1] = BaseDeployer.deployContractPair(
-            initialOwner,
             configHub,
             BaseDeployer.PairConfig({
                 name: "cbBTC/USDC",

--- a/script/libraries/OPBaseSepoliaDeployer.sol
+++ b/script/libraries/OPBaseSepoliaDeployer.sol
@@ -40,13 +40,13 @@ library OPBaseSepoliaDeployer {
         BaseDeployer.setupConfigHub(result.configHub, defaultHubParams());
 
         // pairs
-        result.assetPairContracts = deployAllContractPairs(thisSender, result.configHub);
+        result.assetPairContracts = deployAllContractPairs(result.configHub);
         for (uint i = 0; i < result.assetPairContracts.length; i++) {
             BaseDeployer.setupContractPair(result.configHub, result.assetPairContracts[i]);
         }
 
         // ownership
-        BaseDeployer.nominateNewOwnerAll(finalOwner, result);
+        BaseDeployer.nominateNewHubOwner(finalOwner, result);
     }
 
     function deployMockOracleETHUSD() internal returns (BaseTakerOracle oracle) {
@@ -92,7 +92,7 @@ library OPBaseSepoliaDeployer {
         oracle = BaseDeployer.deployChainlinkOracle(tUSDC, Const.VIRTUAL_ASSET, feedUSDC_USD, sequencerFeed);
     }
 
-    function deployAllContractPairs(address initialOwner, ConfigHub configHub)
+    function deployAllContractPairs(ConfigHub configHub)
         internal
         returns (BaseDeployer.AssetPairContracts[] memory assetPairContracts)
     {
@@ -106,7 +106,6 @@ library OPBaseSepoliaDeployer {
 
         // if any escrowNFT contracts will be reused for multiple pairs, they should be deployed first
         assetPairContracts[0] = BaseDeployer.deployContractPair(
-            initialOwner,
             configHub,
             BaseDeployer.PairConfig({
                 name: "WETH/USDC",
@@ -127,7 +126,6 @@ library OPBaseSepoliaDeployer {
         );
 
         assetPairContracts[1] = BaseDeployer.deployContractPair(
-            initialOwner,
             configHub,
             BaseDeployer.PairConfig({
                 name: "WBTC/USDC",

--- a/src/CollarProviderNFT.sol
+++ b/src/CollarProviderNFT.sol
@@ -48,7 +48,7 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
     uint public constant MAX_PUT_STRIKE_BIPS = BIPS_BASE - 1; // 1 less than 1x
     uint public constant MAX_PROTOCOL_FEE_BIPS = BIPS_BASE / 100; // 1%
 
-    string public constant VERSION = "0.2.0";
+    string public constant VERSION = "0.3.0";
 
     // ----- IMMUTABLES ----- //
     IERC20 public immutable cashAsset;

--- a/src/CollarProviderNFT.sol
+++ b/src/CollarProviderNFT.sol
@@ -65,14 +65,13 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
     mapping(uint positionId => ProviderPositionStored) internal positions;
 
     constructor(
-        address initialOwner,
         ConfigHub _configHub,
         IERC20 _cashAsset,
         IERC20 _underlying,
         address _taker,
         string memory _name,
         string memory _symbol
-    ) BaseNFT(initialOwner, _name, _symbol, _configHub, address(_cashAsset)) {
+    ) BaseNFT(_name, _symbol, _configHub, address(_cashAsset)) {
         cashAsset = _cashAsset;
         underlying = _underlying;
         taker = _taker;
@@ -197,7 +196,7 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
         uint putStrikePercent,
         uint duration,
         uint minLocked
-    ) external whenNotPaused returns (uint offerId) {
+    ) external returns (uint offerId) {
         // sanity checks
         require(callStrikePercent >= MIN_CALL_STRIKE_BIPS, "provider: strike percent too low");
         require(callStrikePercent <= MAX_CALL_STRIKE_BIPS, "provider: strike percent too high");
@@ -230,7 +229,7 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
      * can be a low likelihood concern on a network that exposes a public mempool.
      * Avoid it by not granting excessive ERC-20 approvals.
      */
-    function updateOfferAmount(uint offerId, uint newAmount) external whenNotPaused {
+    function updateOfferAmount(uint offerId, uint newAmount) external {
         LiquidityOfferStored storage offer = liquidityOffers[offerId];
         require(msg.sender == offer.provider, "provider: not offer provider");
 
@@ -267,7 +266,6 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
     /// @return positionId The ID of the newly created position (NFT token ID)
     function mintFromOffer(uint offerId, uint providerLocked, uint takerId)
         external
-        whenNotPaused
         onlyTaker
         returns (uint positionId)
     {
@@ -335,7 +333,7 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
     /// of the NFT abruptly (only prevent settlement at future price).
     /// @param positionId The ID of the position to settle (NFT token ID)
     /// @param cashDelta The change in position value (positive or negative)
-    function settlePosition(uint positionId, int cashDelta) external whenNotPaused onlyTaker {
+    function settlePosition(uint positionId, int cashDelta) external onlyTaker {
         ProviderPositionStored storage position = positions[positionId];
 
         require(position.expiration != 0, "provider: position does not exist");
@@ -371,7 +369,7 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
     /// to settlement, during cancellation the taker's caller MUST be the NFT owner (is the provider),
     /// so is assumed to specify the withdrawal correctly for their funds.
     /// @param positionId The ID of the position to cancel (NFT token ID)
-    function cancelAndWithdraw(uint positionId) external whenNotPaused onlyTaker returns (uint withdrawal) {
+    function cancelAndWithdraw(uint positionId) external onlyTaker returns (uint withdrawal) {
         ProviderPositionStored storage position = positions[positionId];
         require(position.expiration != 0, "provider: position does not exist");
         require(!position.settled, "provider: already settled");
@@ -405,7 +403,7 @@ contract CollarProviderNFT is ICollarProviderNFT, BaseNFT {
     /// @notice Withdraws funds from a settled position. Can only be called for a settled position
     /// (and not a cancelled one), and checks the ownership of the NFT. Burns the NFT.
     /// @param positionId The ID of the settled position to withdraw from (NFT token ID).
-    function withdrawFromSettled(uint positionId) external whenNotPaused returns (uint withdrawal) {
+    function withdrawFromSettled(uint positionId) external returns (uint withdrawal) {
         // Note: _isAuthorized not used here to reduce surface area / KISS. Can be used if needed,
         // since an approved account can pull and withdraw.
         require(msg.sender == ownerOf(positionId), "provider: not position owner");

--- a/src/CollarTakerNFT.sol
+++ b/src/CollarTakerNFT.sol
@@ -46,7 +46,7 @@ contract CollarTakerNFT is ICollarTakerNFT, BaseNFT, ReentrancyGuard {
 
     uint internal constant BIPS_BASE = 10_000;
 
-    string public constant VERSION = "0.2.0";
+    string public constant VERSION = "0.3.0";
 
     // ----- IMMUTABLES ----- //
     IERC20 public immutable cashAsset;

--- a/src/CollarTakerNFT.sol
+++ b/src/CollarTakerNFT.sol
@@ -58,14 +58,13 @@ contract CollarTakerNFT is ICollarTakerNFT, BaseNFT, ReentrancyGuard {
     mapping(uint positionId => TakerPositionStored) internal positions;
 
     constructor(
-        address initialOwner,
         ConfigHub _configHub,
         IERC20 _cashAsset,
         IERC20 _underlying,
         ITakerOracle _oracle,
         string memory _name,
         string memory _symbol
-    ) BaseNFT(initialOwner, _name, _symbol, _configHub, address(_cashAsset)) {
+    ) BaseNFT(_name, _symbol, _configHub, address(_cashAsset)) {
         cashAsset = _cashAsset;
         underlying = _underlying;
         _setOracle(_oracle);
@@ -168,7 +167,6 @@ contract CollarTakerNFT is ICollarTakerNFT, BaseNFT, ReentrancyGuard {
      */
     function openPairedPosition(uint takerLocked, CollarProviderNFT providerNFT, uint offerId)
         external
-        whenNotPaused
         nonReentrant
         returns (uint takerId, uint providerId)
     {
@@ -235,7 +233,7 @@ contract CollarTakerNFT is ICollarTakerNFT, BaseNFT, ReentrancyGuard {
      * one side is not (e.g., due to being at max loss). For this reason a keeper should be run to
      * prevent users with gains from not settling their positions on time.
      */
-    function settlePairedPosition(uint takerId) external whenNotPaused nonReentrant {
+    function settlePairedPosition(uint takerId) external nonReentrant {
         // @dev this checks position exists
         TakerPosition memory position = getPosition(takerId);
 
@@ -270,12 +268,7 @@ contract CollarTakerNFT is ICollarTakerNFT, BaseNFT, ReentrancyGuard {
     /// @notice Withdraws funds from a settled position. Burns the NFT.
     /// @param takerId The ID of the settled position to withdraw from (NFT token ID).
     /// @return withdrawal The amount of cash asset withdrawn
-    function withdrawFromSettled(uint takerId)
-        external
-        whenNotPaused
-        nonReentrant
-        returns (uint withdrawal)
-    {
+    function withdrawFromSettled(uint takerId) external nonReentrant returns (uint withdrawal) {
         require(msg.sender == ownerOf(takerId), "taker: not position owner");
 
         TakerPosition memory position = getPosition(takerId);
@@ -298,12 +291,7 @@ contract CollarTakerNFT is ICollarTakerNFT, BaseNFT, ReentrancyGuard {
      * @param takerId The ID of the taker position to cancel
      * @return withdrawal The amount of funds withdrawn from both positions together
      */
-    function cancelPairedPosition(uint takerId)
-        external
-        whenNotPaused
-        nonReentrant
-        returns (uint withdrawal)
-    {
+    function cancelPairedPosition(uint takerId) external nonReentrant returns (uint withdrawal) {
         TakerPosition memory position = getPosition(takerId);
         (CollarProviderNFT providerNFT, uint providerId) = (position.providerNFT, position.providerId);
 
@@ -338,11 +326,11 @@ contract CollarTakerNFT is ICollarTakerNFT, BaseNFT, ReentrancyGuard {
         );
     }
 
-    // ----- Owner Mutative ----- //
+    // ----- admin Mutative ----- //
 
     /// @notice Sets the price oracle used by the contract
     /// @param _oracle The new price oracle to use
-    function setOracle(ITakerOracle _oracle) external onlyOwner {
+    function setOracle(ITakerOracle _oracle) external onlyConfigHubOwner {
         _setOracle(_oracle);
     }
 

--- a/src/EscrowSupplierNFT.sol
+++ b/src/EscrowSupplierNFT.sol
@@ -52,7 +52,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
     // @notice max percentage of refunded interest fee, prevents free cancellation issues
     uint public constant MAX_FEE_REFUND_BIPS = 9500; // 95%
 
-    string public constant VERSION = "0.2.0";
+    string public constant VERSION = "0.3.0";
 
     // ----- IMMUTABLES ----- //
     IERC20 public immutable asset; // corresponds to Loans' underlying

--- a/src/EscrowSupplierNFT.sol
+++ b/src/EscrowSupplierNFT.sol
@@ -68,13 +68,9 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
 
     mapping(uint escrowId => EscrowStored) internal escrows;
 
-    constructor(
-        address initialOwner,
-        ConfigHub _configHub,
-        IERC20 _asset,
-        string memory _name,
-        string memory _symbol
-    ) BaseNFT(initialOwner, _name, _symbol, _configHub, address(_asset)) {
+    constructor(ConfigHub _configHub, IERC20 _asset, string memory _name, string memory _symbol)
+        BaseNFT(_name, _symbol, _configHub, address(_asset))
+    {
         asset = _asset;
     }
 
@@ -195,7 +191,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
         uint gracePeriod,
         uint lateFeeAPR,
         uint minEscrow
-    ) external whenNotPaused returns (uint offerId) {
+    ) external returns (uint offerId) {
         // sanity checks
         require(interestAPR <= MAX_INTEREST_APR_BIPS, "escrow: interest APR too high");
         require(lateFeeAPR <= MAX_LATE_FEE_APR_BIPS, "escrow: late fee APR too high");
@@ -228,7 +224,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
      * can be a low likelihood concern on a network that exposes a public mempool.
      * Avoid it by not granting excessive ERC-20 approvals.
      */
-    function updateOfferAmount(uint offerId, uint newAmount) external whenNotPaused {
+    function updateOfferAmount(uint offerId, uint newAmount) external {
         OfferStored storage offer = offers[offerId];
         require(msg.sender == offer.supplier, "escrow: not offer supplier");
 
@@ -267,7 +263,6 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
      */
     function startEscrow(uint offerId, uint escrowed, uint fees, uint loanId)
         external
-        whenNotPaused
         returns (uint escrowId)
     {
         // @dev msg.sender auth is checked vs. loansCanOpen in _startEscrow
@@ -292,7 +287,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
      *   but doesn't have to be. Any under or overpayment, or fee refunds will effect toLoans.
      * @return toLoans Amount to be returned to loans (refund deducing shortfalls)
      */
-    function endEscrow(uint escrowId, uint repaid) external whenNotPaused returns (uint toLoans) {
+    function endEscrow(uint escrowId, uint repaid) external returns (uint toLoans) {
         // @dev msg.sender auth is checked vs. stored loans in _endEscrow
         toLoans = _endEscrow(escrowId, getEscrow(escrowId), repaid);
 
@@ -322,7 +317,6 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
      */
     function switchEscrow(uint releaseEscrowId, uint offerId, uint newFees, uint newLoanId)
         external
-        whenNotPaused
         returns (uint newEscrowId, uint feesRefund)
     {
         Escrow memory previousEscrow = getEscrow(releaseEscrowId);
@@ -362,7 +356,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
 
     /// @notice Withdraws funds from a released escrow. Burns the NFT.
     /// @param escrowId The ID of the escrow to withdraw from
-    function withdrawReleased(uint escrowId) external whenNotPaused {
+    function withdrawReleased(uint escrowId) external {
         require(msg.sender == ownerOf(escrowId), "escrow: not escrow owner"); // will revert for burned
 
         Escrow memory escrow = getEscrow(escrowId);
@@ -388,7 +382,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
      * In either case, escrow owner withdraws full principal, interest, and late fees.
      * @param escrowId The ID of the escrow to seize
      */
-    function seizeEscrow(uint escrowId) external whenNotPaused {
+    function seizeEscrow(uint escrowId) external {
         require(msg.sender == ownerOf(escrowId), "escrow: not escrow owner"); // will revert for burned
 
         Escrow memory escrow = getEscrow(escrowId);
@@ -413,7 +407,7 @@ contract EscrowSupplierNFT is IEscrowSupplierNFT, BaseNFT {
     // ----- admin ----- //
 
     /// @notice Sets whether a Loans contract is allowed to interact with this contract
-    function setLoansCanOpen(address loans, bool allowed) external onlyOwner {
+    function setLoansCanOpen(address loans, bool allowed) external onlyConfigHubOwner {
         // @dev no checks for Loans interface since calls are only from Loans to this contract
         loansCanOpen[loans] = allowed;
         emit LoansCanOpenSet(loans, allowed);

--- a/src/LoansNFT.sol
+++ b/src/LoansNFT.sol
@@ -48,7 +48,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
 
     uint internal constant BIPS_BASE = 10_000;
 
-    string public constant VERSION = "0.2.0";
+    string public constant VERSION = "0.3.0";
     uint public constant MAX_SWAP_PRICE_DEVIATION_BIPS = 1000; // 10%, allows 10% self-sandwich slippage
 
     // ----- IMMUTABLES ----- //

--- a/src/Rolls.sol
+++ b/src/Rolls.sol
@@ -49,7 +49,7 @@ contract Rolls is IRolls {
 
     uint internal constant BIPS_BASE = 10_000;
 
-    string public constant VERSION = "0.2.0";
+    string public constant VERSION = "0.3.0";
 
     // ----- IMMUTABLES ----- //
     CollarTakerNFT public immutable takerNFT;

--- a/src/Rolls.sol
+++ b/src/Rolls.sol
@@ -7,7 +7,6 @@ import { SignedMath } from "@openzeppelin/contracts/utils/math/SignedMath.sol";
 
 import { CollarTakerNFT, ICollarTakerNFT } from "./CollarTakerNFT.sol";
 import { CollarProviderNFT, ICollarProviderNFT } from "./CollarProviderNFT.sol";
-import { BaseManaged } from "./base/BaseManaged.sol";
 import { IRolls } from "./interfaces/IRolls.sol";
 
 /**
@@ -44,7 +43,7 @@ import { IRolls } from "./interfaces/IRolls.sol";
  * - ConfigHub: If this contract is used through Loans, set setCanOpenPair() to authorize this
  * contract for its asset pair
  */
-contract Rolls is IRolls, BaseManaged {
+contract Rolls is IRolls {
     using SafeERC20 for IERC20;
     using SafeCast for uint;
 
@@ -62,18 +61,10 @@ contract Rolls is IRolls, BaseManaged {
 
     mapping(uint rollId => RollOfferStored) internal rollOffers;
 
-    /// @dev Rolls needs BaseManaged for pausing since is approved by users, and holds NFTs.
-    /// Does not need `canOpen` auth here because its auth is checked in Loans, or requires no auth
+    /// @dev Rolls does not need `canOpen` auth because its auth is checked in Loans, or requires no auth
     /// if used directly.
     /// Has no long-lived functionality so doesn't need a close-only migration mode.
-    /// @dev unrescuableAsset is not set, which means that providerNFTs held by this contract for active
-    /// offers can be rescued by the owner via `rescueTokens`. In a future implementation this can be set
-    /// to a specific providerNFT if needed (limiting the Rolls contract to a single provider NFT). Currently,
-    /// because roll offers are short lived and optional, the added complexity is not worth it wrt
-    /// to the risk mitigated by it.
-    constructor(address initialOwner, CollarTakerNFT _takerNFT)
-        BaseManaged(initialOwner, _takerNFT.configHub(), address(0))
-    {
+    constructor(CollarTakerNFT _takerNFT) {
         takerNFT = _takerNFT;
         cashAsset = _takerNFT.cashAsset();
     }
@@ -184,7 +175,7 @@ contract Rolls is IRolls, BaseManaged {
         uint maxPrice,
         int minToProvider,
         uint deadline
-    ) external whenNotPaused returns (uint rollId) {
+    ) external returns (uint rollId) {
         // taker position is valid
         ICollarTakerNFT.TakerPosition memory takerPos = takerNFT.getPosition(takerId);
         require(takerPos.expiration != 0, "rolls: taker position does not exist");
@@ -232,7 +223,7 @@ contract Rolls is IRolls, BaseManaged {
      * The risk of update is different here from providerNFT.updateOfferAmount because
      * the most an update can cause there is a revert of taking the offer.
      */
-    function cancelOffer(uint rollId) external whenNotPaused {
+    function cancelOffer(uint rollId) external {
         RollOffer memory offer = getRollOffer(rollId);
         require(msg.sender == offer.provider, "rolls: not offer provider");
         require(offer.active, "rolls: offer not active");
@@ -258,7 +249,6 @@ contract Rolls is IRolls, BaseManaged {
      */
     function executeRoll(uint rollId, int minToTaker)
         external
-        whenNotPaused
         returns (uint newTakerId, uint newProviderId, int toTaker, int toProvider)
     {
         RollOffer memory offer = getRollOffer(rollId);

--- a/src/Rolls.sol
+++ b/src/Rolls.sol
@@ -398,7 +398,8 @@ contract Rolls is IRolls, BaseManaged {
         (uint newTakerLocked, uint newProviderLocked) = _newLockedAmounts(takerPos, newPrice);
 
         // new protocol fee. @dev there is no refund for previously paid protocol fee
-        (uint protocolFee,) = takerPos.providerNFT.protocolFee(newProviderLocked, takerPos.duration);
+        (uint protocolFee,) =
+            takerPos.providerNFT.protocolFee(newProviderLocked, takerPos.duration, takerPos.callStrikePercent);
 
         // The taker and provider external balances (before fee) should be updated as if
         // they settled and withdrawn the old positions, and opened the new positions.

--- a/src/base/BaseManaged.sol
+++ b/src/base/BaseManaged.sol
@@ -2,100 +2,87 @@
 pragma solidity 0.8.22;
 
 import { SafeERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import { Ownable2Step, Ownable } from "@openzeppelin/contracts/access/Ownable2Step.sol";
-import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
-import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 import { ConfigHub } from "../ConfigHub.sol";
 
 /**
  * @title BaseManaged
- * @notice Base contract for managed contracts in the Collar Protocol
- * @dev This contract provides common functionality for contracts that are owned and managed
- * via the Collar Protocol's ConfigHub. It includes 2 step ownership, pause/unpause functionality,
- * pause guardian pausing, and a function to rescue stuck tokens.
- * @dev all inheriting contracts that hold funds should be owned by a secure multi-sig due
- * the sensitive onlyOwner methods.
+ * @notice Base contract for managed contracts in the protocol
+ * @dev This contract provides common functionality for contracts that are managed
+ * via the a common ConfigHub. It includes a onlyConfigHubOwner that can control access to
+ * configuration value setters in inheriting contracts, and a function to rescue stuck tokens.
+ * @dev ConfigHub should be owned by a secure multi-sig due the sensitive onlyConfigHubOwner methods.
  */
-abstract contract BaseManaged is Ownable2Step, Pausable {
+abstract contract BaseManaged {
     // ----- State ----- //
     ConfigHub public configHub;
 
     /**
-     * @notice a token address (ERC-20 or ERC-721) that the owner can NOT rescue via `rescueTokens`.
+     * @notice a token address (ERC-20 or ERC-721) that configHub's owner can NOT rescue via `rescueTokens`.
      *  This should be the main asset that the contract holds at rest on behalf of its users.
      *  If this asset is sent to the contract by mistake, there is no way to rescue it.
      *  This exclusion reduces the centralisation risk, and reduces the impact, incentive, and
-     *  thus also the likelihood of compromizing the owner.
+     *  thus also the likelihood of compromizing the configHub's owner.
      * @dev this is a single address because currently only a single asset is held by each contract
      *  at rest (except for Rolls).
      *  Other assets, that may be held by the contract in-transit (during a transaction), can be rescued.
-     *  If further reduction of centralization risk is required, this should become a Set.
+     *  If more assets need to be unrescuable, this should become a Set.
      */
     address public immutable unrescuableAsset;
 
     // ----- Events ----- //
     event ConfigHubUpdated(ConfigHub previousConfigHub, ConfigHub newConfigHub);
-    event PausedByGuardian(address guardian);
     event TokensRescued(address tokenContract, uint amountOrId);
 
-    constructor(address _initialOwner, ConfigHub _configHub, address _unrescuableAsset)
-        Ownable(_initialOwner)
-    {
+    constructor(ConfigHub _configHub, address _unrescuableAsset) {
         _setConfigHub(_configHub);
         unrescuableAsset = _unrescuableAsset;
     }
 
+    // ----- Modifiers ----- //
+
+    modifier onlyConfigHubOwner() {
+        require(msg.sender == configHub.owner(), "BaseManaged: not configHub owner");
+        _;
+    }
+
+    // ----- Views ----- //
+
+    function configHubOwner() public view returns (address) {
+        return configHub.owner();
+    }
+
     // ----- MUTATIVE ----- //
 
-    // ----- Non-owner ----- //
+    // ----- onlyConfigHubOwner ----- //
 
-    // @notice Pause method called from a guardian authorized by the ConfigHub in case of emergency
-    // Reverts if sender is not guardian, or if owner is revoked (since unpausing would be impossible)
-    function pauseByGuardian() external {
-        require(configHub.isPauseGuardian(msg.sender), "not guardian");
-        // if owner is renounced, no one will be able to call unpause.
-        // Using Ownable2Step ensures the owner can only be renounced to address(0).
-        require(owner() != address(0), "owner renounced");
-
-        _pause(); // @dev also emits Paused
-        emit PausedByGuardian(msg.sender);
-    }
-
-    // ----- owner ----- //
-
-    /// @notice Pauses the contract when called by the contract owner in case of emergency.
-    function pause() external onlyOwner {
-        _pause();
-    }
-
-    /// @notice Unpauses the contract when called by the contract owner
-    function unpause() external onlyOwner {
-        _unpause();
-    }
-
-    /// @notice Updates the address of the ConfigHub contract when called by the contract owner
-    function setConfigHub(ConfigHub _newConfigHub) external onlyOwner {
+    /// @notice Updates the address of the ConfigHub contract when called by the current configHub's owner.
+    /// Only allows switching to a new configHub whose owner is the same as current configHub's owner.
+    /// @dev To renounce access to specific contracts use setConfigHub to set a new configHub controlled
+    /// by the same owner, and then renounce its ownership.
+    function setConfigHub(ConfigHub _newConfigHub) external onlyConfigHubOwner {
+        // check owner view exists and returns same address to prevent accidentally getting locked out.
+        require(_newConfigHub.owner() == configHubOwner(), "BaseManaged: new configHub owner mismatch");
         _setConfigHub(_newConfigHub);
     }
 
     /**
-     * @notice Sends an amount of an ERC-20, or an ID of any ERC-721, to owner's address.
+     * @notice Sends an amount of an ERC-20, or an ID of any ERC-721, to configHub owner's address.
      * Reverts if the `token` matches the `unrescuableAsset`.
      * To be used to rescue stuck assets that were sent to the contract by mistake.
-     * @dev Only callable by the contract owner.
+     * @dev Only callable by the configHub's owner.
      * @param token The address of the token contract
      * @param amountOrId The amount of tokens to rescue (or token ID for NFTs)
      * @param isNFT Whether the token is an NFT (true) or an ERC-20 (false)
      */
-    function rescueTokens(address token, uint amountOrId, bool isNFT) external onlyOwner {
+    function rescueTokens(address token, uint amountOrId, bool isNFT) external onlyConfigHubOwner {
         require(token != unrescuableAsset, "unrescuable asset");
         if (isNFT) {
-            IERC721(token).transferFrom(address(this), owner(), amountOrId);
+            IERC721(token).transferFrom(address(this), configHubOwner(), amountOrId);
         } else {
             // for ERC-20 must use transfer, since most implementation won't allow transferFrom
             // without approve (even from owner)
-            SafeERC20.safeTransfer(IERC20(token), owner(), amountOrId);
+            SafeERC20.safeTransfer(IERC20(token), configHubOwner(), amountOrId);
         }
         emit TokensRescued(token, amountOrId);
     }

--- a/src/base/BaseManaged.sol
+++ b/src/base/BaseManaged.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.22;
 
 import { SafeERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 import { ConfigHub } from "../ConfigHub.sol";
 

--- a/src/base/BaseNFT.sol
+++ b/src/base/BaseNFT.sol
@@ -7,7 +7,7 @@ import { BaseManaged, ConfigHub } from "./BaseManaged.sol";
 
 /**
  * @title BaseNFT
- * @notice Base contract for NFTs in the Collar Protocol. It provides the admin functionality
+ * @notice Base contract for NFTs in the protocol. It provides the admin functionality
  * from BaseManaged, and the NFT metadata base URI.
  */
 abstract contract BaseNFT is BaseManaged, ERC721 {
@@ -16,13 +16,10 @@ abstract contract BaseNFT is BaseManaged, ERC721 {
     // ----- State ----- //
     uint internal nextTokenId = 1; // NFT token ID, starts from 1 so that 0 ID is not used
 
-    constructor(
-        address _initialOwner,
-        string memory _name,
-        string memory _symbol,
-        ConfigHub _configHub,
-        address _unrescuableAsset
-    ) BaseManaged(_initialOwner, _configHub, _unrescuableAsset) ERC721(_name, _symbol) { }
+    constructor(string memory _name, string memory _symbol, ConfigHub _configHub, address _unrescuableAsset)
+        BaseManaged(_configHub, _unrescuableAsset)
+        ERC721(_name, _symbol)
+    { }
 
     // ----- INTERNAL ----- //
 

--- a/test/integration/full-protocol/AssetDeployForkTest.t.sol
+++ b/test/integration/full-protocol/AssetDeployForkTest.t.sol
@@ -89,7 +89,6 @@ contract AssetDeployForkTest is BaseAssetPairForkTest {
         // deploy and configure new pair
         pairs = new BaseDeployer.AssetPairContracts[](1);
         pairs[0] = BaseDeployer.deployContractPair(
-            owner,
             hub,
             BaseDeployer.PairConfig({
                 name: "tWBTC-tUSDC",

--- a/test/integration/full-protocol/BaseAssetPairForkTest.sol
+++ b/test/integration/full-protocol/BaseAssetPairForkTest.sol
@@ -362,27 +362,25 @@ abstract contract BaseAssetPairForkTest is Test {
         assertEq(pair.oracle.description(), oracleDescription);
 
         // taker
-        assertEq(address(pair.takerNFT.owner()), owner);
+        assertEq(address(pair.takerNFT.configHubOwner()), owner);
         assertEq(address(pair.takerNFT.configHub()), address(configHub));
         assertEq(address(pair.takerNFT.underlying()), address(pair.underlying));
         assertEq(address(pair.takerNFT.cashAsset()), address(pair.cashAsset));
         assertEq(address(pair.takerNFT.oracle()), address(pair.oracle));
 
         // provider
-        assertEq(address(pair.providerNFT.owner()), owner);
+        assertEq(address(pair.providerNFT.configHubOwner()), owner);
         assertEq(address(pair.providerNFT.configHub()), address(configHub));
         assertEq(address(pair.providerNFT.underlying()), address(pair.underlying));
         assertEq(address(pair.providerNFT.cashAsset()), address(pair.cashAsset));
         assertEq(address(pair.providerNFT.taker()), address(pair.takerNFT));
 
         // rolls
-        assertEq(address(pair.rollsContract.owner()), owner);
-        assertEq(address(pair.rollsContract.configHub()), address(configHub));
         assertEq(address(pair.rollsContract.takerNFT()), address(pair.takerNFT));
         assertEq(address(pair.rollsContract.cashAsset()), address(pair.cashAsset));
 
         // loans
-        assertEq(address(pair.loansContract.owner()), owner);
+        assertEq(address(pair.loansContract.configHubOwner()), owner);
         assertEq(address(pair.loansContract.configHub()), address(configHub));
         assertEq(address(pair.loansContract.takerNFT()), address(pair.takerNFT));
         assertEq(address(pair.loansContract.underlying()), address(pair.underlying));
@@ -396,7 +394,7 @@ abstract contract BaseAssetPairForkTest is Test {
         assertEq(pair.loansContract.closingKeeper(), address(0));
 
         // escrow
-        assertEq(address(pair.escrowNFT.owner()), owner);
+        assertEq(address(pair.escrowNFT.configHubOwner()), owner);
         assertEq(address(pair.escrowNFT.configHub()), address(configHub));
         assertTrue(pair.escrowNFT.loansCanOpen(address(pair.loansContract)));
         assertEq(address(pair.escrowNFT.asset()), address(pair.underlying));

--- a/test/integration/full-protocol/BaseAssetPairForkTest.sol
+++ b/test/integration/full-protocol/BaseAssetPairForkTest.sol
@@ -351,6 +351,7 @@ abstract contract BaseAssetPairForkTest is Test {
 
     function test_validatePairDeployment() public view {
         // configHub
+        assertEq(configHub.VERSION(), "0.2.0");
         assertEq(configHub.owner(), owner);
         assertEq(uint(configHub.protocolFeeAPR()), protocolFeeAPR);
         assertEq(configHub.feeRecipient(), protocolFeeRecipient);
@@ -362,6 +363,7 @@ abstract contract BaseAssetPairForkTest is Test {
         assertEq(pair.oracle.description(), oracleDescription);
 
         // taker
+        assertEq(pair.takerNFT.VERSION(), "0.3.0");
         assertEq(address(pair.takerNFT.configHubOwner()), owner);
         assertEq(address(pair.takerNFT.configHub()), address(configHub));
         assertEq(address(pair.takerNFT.underlying()), address(pair.underlying));
@@ -369,6 +371,7 @@ abstract contract BaseAssetPairForkTest is Test {
         assertEq(address(pair.takerNFT.oracle()), address(pair.oracle));
 
         // provider
+        assertEq(pair.providerNFT.VERSION(), "0.3.0");
         assertEq(address(pair.providerNFT.configHubOwner()), owner);
         assertEq(address(pair.providerNFT.configHub()), address(configHub));
         assertEq(address(pair.providerNFT.underlying()), address(pair.underlying));
@@ -376,10 +379,12 @@ abstract contract BaseAssetPairForkTest is Test {
         assertEq(address(pair.providerNFT.taker()), address(pair.takerNFT));
 
         // rolls
+        assertEq(pair.rollsContract.VERSION(), "0.3.0");
         assertEq(address(pair.rollsContract.takerNFT()), address(pair.takerNFT));
         assertEq(address(pair.rollsContract.cashAsset()), address(pair.cashAsset));
 
         // loans
+        assertEq(pair.loansContract.VERSION(), "0.3.0");
         assertEq(address(pair.loansContract.configHubOwner()), owner);
         assertEq(address(pair.loansContract.configHub()), address(configHub));
         assertEq(address(pair.loansContract.takerNFT()), address(pair.takerNFT));
@@ -394,6 +399,7 @@ abstract contract BaseAssetPairForkTest is Test {
         assertEq(pair.loansContract.closingKeeper(), address(0));
 
         // escrow
+        assertEq(pair.escrowNFT.VERSION(), "0.3.0");
         assertEq(address(pair.escrowNFT.configHubOwner()), owner);
         assertEq(address(pair.escrowNFT.configHub()), address(configHub));
         assertTrue(pair.escrowNFT.loansCanOpen(address(pair.loansContract)));

--- a/test/integration/full-protocol/BaseAssetPairForkTest.sol
+++ b/test/integration/full-protocol/BaseAssetPairForkTest.sol
@@ -319,7 +319,7 @@ abstract contract BaseAssetPairForkTest is Test {
         // Calculate protocol fee based on post-swap provider locked amount
         uint swapOut = loanAmount * BIPS_BASE / ltv;
         uint initProviderLocked = swapOut * (callstrikeToUse - BIPS_BASE) / BIPS_BASE;
-        (protocolFee,) = pair.providerNFT.protocolFee(initProviderLocked, duration);
+        (protocolFee,) = pair.providerNFT.protocolFee(initProviderLocked, duration, callstrikeToUse);
         assertGt(protocolFee, 0);
     }
 

--- a/test/unit/BaseAssetPairTestSetup.sol
+++ b/test/unit/BaseAssetPairTestSetup.sol
@@ -75,15 +75,14 @@ contract BaseAssetPairTestSetup is Test {
 
         // taker checks oracle price on construction
         updatePrice();
-        takerNFT = new CollarTakerNFT(
-            owner, configHub, cashAsset, underlying, chainlinkOracle, "CollarTakerNFT", "TKRNFT"
-        );
+        takerNFT =
+            new CollarTakerNFT(configHub, cashAsset, underlying, chainlinkOracle, "CollarTakerNFT", "TKRNFT");
         providerNFT = new CollarProviderNFT(
-            owner, configHub, cashAsset, underlying, address(takerNFT), "ProviderNFT", "PRVNFT"
+            configHub, cashAsset, underlying, address(takerNFT), "ProviderNFT", "PRVNFT"
         );
         // this is to avoid having the paired IDs being equal
         providerNFT2 = new CollarProviderNFT(
-            owner, configHub, cashAsset, underlying, address(takerNFT), "ProviderNFT-2", "PRVNFT-2"
+            configHub, cashAsset, underlying, address(takerNFT), "ProviderNFT-2", "PRVNFT-2"
         );
         vm.label(address(chainlinkOracle), "MockChainlinkOracle");
         vm.label(address(takerNFT), "CollarTakerNFT");

--- a/test/unit/BaseAssetPairTestSetup.sol
+++ b/test/unit/BaseAssetPairTestSetup.sol
@@ -90,7 +90,7 @@ contract BaseAssetPairTestSetup is Test {
         vm.label(address(providerNFT), "CollarProviderNFT");
 
         // asset pair periphery
-        rolls = new Rolls(owner, takerNFT);
+        rolls = new Rolls(takerNFT);
         vm.label(address(rolls), "Rolls");
     }
 

--- a/test/unit/BaseManaged.all.t.sol
+++ b/test/unit/BaseManaged.all.t.sol
@@ -308,13 +308,3 @@ contract LoansManagedTest is TakerNFTManagedTest {
         testedContract = new LoansNFT(owner, takerNFT, "", "");
     }
 }
-
-contract RollsManagedTest is TakerNFTManagedTest {
-    function setupTestedContract() internal override {
-        super.setupTestedContract();
-        // take the taker contract setup by the super
-        CollarTakerNFT takerNFT = CollarTakerNFT(address(testedContract));
-        unrescuable = address(0);
-        testedContract = new Rolls(owner, takerNFT);
-    }
-}

--- a/test/unit/CollarProviderNFT.t.sol
+++ b/test/unit/CollarProviderNFT.t.sol
@@ -142,7 +142,7 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         assertEq(newProviderNFT.MAX_CALL_STRIKE_BIPS(), 100_000);
         assertEq(newProviderNFT.MAX_PUT_STRIKE_BIPS(), 9999);
         assertEq(newProviderNFT.MAX_PROTOCOL_FEE_BIPS(), 100);
-        assertEq(newProviderNFT.VERSION(), "0.2.0");
+        assertEq(newProviderNFT.VERSION(), "0.3.0");
         assertEq(newProviderNFT.name(), "NewCollarProviderNFT");
         assertEq(newProviderNFT.symbol(), "NPRVNFT");
     }

--- a/test/unit/CollarProviderNFT.t.sol
+++ b/test/unit/CollarProviderNFT.t.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.22;
 
 import "forge-std/Test.sol";
 import { IERC721Errors, Strings } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
 import { TestERC20 } from "../utils/TestERC20.sol";
 
 import { BaseAssetPairTestSetup } from "./BaseAssetPairTestSetup.sol";
@@ -130,10 +129,10 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
 
     function test_constructor() public {
         CollarProviderNFT newProviderNFT = new CollarProviderNFT(
-            owner, configHub, cashAsset, underlying, address(takerContract), "NewCollarProviderNFT", "NPRVNFT"
+            configHub, cashAsset, underlying, address(takerContract), "NewCollarProviderNFT", "NPRVNFT"
         );
 
-        assertEq(address(newProviderNFT.owner()), owner);
+        assertEq(address(newProviderNFT.configHubOwner()), owner);
         assertEq(address(newProviderNFT.configHub()), address(configHub));
         assertEq(newProviderNFT.unrescuableAsset(), address(cashAsset));
         assertEq(address(newProviderNFT.cashAsset()), address(cashAsset));
@@ -498,17 +497,6 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
         providerNFT.cancelAndWithdraw(positionId);
     }
 
-    function test_unpause() public {
-        vm.startPrank(owner);
-        providerNFT.pause();
-        vm.expectEmit(address(providerNFT));
-        emit Pausable.Unpaused(owner);
-        providerNFT.unpause();
-        assertFalse(providerNFT.paused());
-        // check at least one method workds now
-        createAndCheckOffer(provider, largeCash);
-    }
-
     /// Interactions between multiple items
 
     function test_createMultipleOffersFromSameProvider() public {
@@ -611,39 +599,6 @@ contract CollarProviderNFTTest is BaseAssetPairTestSetup {
     }
 
     /// Reverts
-
-    function test_pausableMethods() public {
-        // create a position
-        (uint positionId,) = createAndCheckPosition(provider, largeCash, largeCash / 2);
-
-        // pause
-        vm.startPrank(owner);
-        vm.expectEmit(address(providerNFT));
-        emit Pausable.Paused(owner);
-        providerNFT.pause();
-        // paused view
-        assertTrue(providerNFT.paused());
-        // methods are paused
-        vm.startPrank(provider);
-
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        providerNFT.createOffer(0, 0, 0, 0, 0);
-
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        providerNFT.updateOfferAmount(0, 0);
-
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        providerNFT.mintFromOffer(0, 0, 0);
-
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        providerNFT.settlePosition(0, 0);
-
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        providerNFT.withdrawFromSettled(0);
-
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        providerNFT.cancelAndWithdraw(0);
-    }
 
     function test_revert_createOffer_invalidParams() public {
         uint minStrike = providerNFT.MIN_CALL_STRIKE_BIPS();

--- a/test/unit/CollarTakerNFT.t.sol
+++ b/test/unit/CollarTakerNFT.t.sol
@@ -232,7 +232,7 @@ contract CollarTakerNFTTest is BaseAssetPairTestSetup {
         assertEq(address(takerNFT.cashAsset()), address(cashAsset));
         assertEq(address(takerNFT.underlying()), address(underlying));
         assertEq(address(takerNFT.oracle()), address(chainlinkOracle));
-        assertEq(takerNFT.VERSION(), "0.2.0");
+        assertEq(takerNFT.VERSION(), "0.3.0");
         assertEq(takerNFT.name(), "NewCollarTakerNFT");
         assertEq(takerNFT.symbol(), "NBPNFT");
         assertEq(takerNFT.nextPositionId(), 1);

--- a/test/unit/EscrowSupplierNFT.effects.t.sol
+++ b/test/unit/EscrowSupplierNFT.effects.t.sol
@@ -295,7 +295,7 @@ contract EscrowSupplierNFT_BasicEffectsTest is BaseEscrowSupplierNFTTest {
         assertEq(newEscrowSupplierNFT.MAX_GRACE_PERIOD(), 30 days);
         assertEq(newEscrowSupplierNFT.MAX_LATE_FEE_APR_BIPS(), 12 * BIPS_100PCT);
         assertEq(newEscrowSupplierNFT.MAX_FEE_REFUND_BIPS(), 9500);
-        assertEq(newEscrowSupplierNFT.VERSION(), "0.2.0");
+        assertEq(newEscrowSupplierNFT.VERSION(), "0.3.0");
         assertEq(newEscrowSupplierNFT.name(), "NewEscrowSupplierNFT");
         assertEq(newEscrowSupplierNFT.symbol(), "NESNFT");
     }

--- a/test/unit/EscrowSupplierNFT.effects.t.sol
+++ b/test/unit/EscrowSupplierNFT.effects.t.sol
@@ -28,7 +28,7 @@ contract BaseEscrowSupplierNFTTest is BaseAssetPairTestSetup {
     function setUp() public override {
         super.setUp();
         asset = underlying;
-        escrowNFT = new EscrowSupplierNFT(owner, configHub, asset, "ES Test", "ES Test");
+        escrowNFT = new EscrowSupplierNFT(configHub, asset, "ES Test", "ES Test");
 
         setCanOpenSingle(address(escrowNFT), true);
         setCanOpen(loans, true);
@@ -284,9 +284,9 @@ contract BaseEscrowSupplierNFTTest is BaseAssetPairTestSetup {
 contract EscrowSupplierNFT_BasicEffectsTest is BaseEscrowSupplierNFTTest {
     function test_constructor() public {
         EscrowSupplierNFT newEscrowSupplierNFT =
-            new EscrowSupplierNFT(owner, configHub, asset, "NewEscrowSupplierNFT", "NESNFT");
+            new EscrowSupplierNFT(configHub, asset, "NewEscrowSupplierNFT", "NESNFT");
 
-        assertEq(address(newEscrowSupplierNFT.owner()), owner);
+        assertEq(address(newEscrowSupplierNFT.configHubOwner()), owner);
         assertEq(address(newEscrowSupplierNFT.configHub()), address(configHub));
         assertEq(newEscrowSupplierNFT.unrescuableAsset(), address(asset));
         assertEq(address(newEscrowSupplierNFT.asset()), address(asset));

--- a/test/unit/Loans.basic.effects.t.sol
+++ b/test/unit/Loans.basic.effects.t.sol
@@ -445,7 +445,7 @@ contract LoansBasicEffectsTest is LoansTestBase {
         assertEq(address(loans.takerNFT()), address(takerNFT));
         assertEq(address(loans.cashAsset()), address(cashAsset));
         assertEq(address(loans.underlying()), address(underlying));
-        assertEq(loans.VERSION(), "0.2.0");
+        assertEq(loans.VERSION(), "0.3.0");
         assertEq(loans.configHubOwner(), owner);
         assertEq(loans.closingKeeper(), address(0));
         assertEq(address(loans.defaultSwapper()), address(0));

--- a/test/unit/Loans.basic.effects.t.sol
+++ b/test/unit/Loans.basic.effects.t.sol
@@ -56,10 +56,10 @@ contract LoansTestBase is BaseAssetPairTestSetup {
         vm.label(address(mockSwapperRouter), "MockSwapRouter");
         vm.label(address(swapperUniV3), "SwapperUniV3");
         // escrow
-        escrowNFT = new EscrowSupplierNFT(owner, configHub, underlying, "Escrow", "Escrow");
+        escrowNFT = new EscrowSupplierNFT(configHub, underlying, "Escrow", "Escrow");
         vm.label(address(escrowNFT), "Escrow");
         // loans
-        loans = new LoansNFT(owner, takerNFT, "Loans", "Loans");
+        loans = new LoansNFT(takerNFT, "Loans", "Loans");
         vm.label(address(loans), "Loans");
 
         // config
@@ -438,7 +438,7 @@ contract LoansBasicEffectsTest is LoansTestBase {
     // tests
 
     function test_constructor() public {
-        loans = new LoansNFT(owner, takerNFT, "", "");
+        loans = new LoansNFT(takerNFT, "", "");
         assertEq(loans.MAX_SWAP_PRICE_DEVIATION_BIPS(), 1000);
         assertEq(address(loans.configHub()), address(configHub));
         assertEq(loans.unrescuableAsset(), address(takerNFT));
@@ -446,7 +446,7 @@ contract LoansBasicEffectsTest is LoansTestBase {
         assertEq(address(loans.cashAsset()), address(cashAsset));
         assertEq(address(loans.underlying()), address(underlying));
         assertEq(loans.VERSION(), "0.2.0");
-        assertEq(loans.owner(), owner);
+        assertEq(loans.configHubOwner(), owner);
         assertEq(loans.closingKeeper(), address(0));
         assertEq(address(loans.defaultSwapper()), address(0));
         assertEq(loans.name(), "");

--- a/test/unit/Loans.basic.effects.t.sol
+++ b/test/unit/Loans.basic.effects.t.sol
@@ -182,7 +182,7 @@ contract LoansTestBase is BaseAssetPairTestSetup {
 
         uint expectedLoanAmount = swapOut * ltv / BIPS_100PCT;
         uint expectedProviderLocked = swapOut * (callStrikePercent - BIPS_100PCT) / BIPS_100PCT;
-        (uint expectedProtocolFee,) = providerNFT.protocolFee(expectedProviderLocked, duration);
+        (uint expectedProtocolFee,) = providerNFT.protocolFee(expectedProviderLocked, duration, callStrikePercent);
         if (expectedProviderLocked != 0) assertGt(expectedProtocolFee, 0); // ensure fee is expected
 
         ILoansNFT.SwapParams memory swapParams = defaultSwapParams(swapCashAmount);

--- a/test/unit/Loans.basic.effects.t.sol
+++ b/test/unit/Loans.basic.effects.t.sol
@@ -182,7 +182,8 @@ contract LoansTestBase is BaseAssetPairTestSetup {
 
         uint expectedLoanAmount = swapOut * ltv / BIPS_100PCT;
         uint expectedProviderLocked = swapOut * (callStrikePercent - BIPS_100PCT) / BIPS_100PCT;
-        (uint expectedProtocolFee,) = providerNFT.protocolFee(expectedProviderLocked, duration, callStrikePercent);
+        (uint expectedProtocolFee,) =
+            providerNFT.protocolFee(expectedProviderLocked, duration, callStrikePercent);
         if (expectedProviderLocked != 0) assertGt(expectedProtocolFee, 0); // ensure fee is expected
 
         ILoansNFT.SwapParams memory swapParams = defaultSwapParams(swapCashAmount);

--- a/test/unit/Loans.escrow.reverts.t.sol
+++ b/test/unit/Loans.escrow.reverts.t.sol
@@ -45,7 +45,7 @@ contract LoansEscrowRevertsTest is LoansBasicRevertsTest {
         openLoan(underlyingAmount, minLoanAmount, 0, 0);
 
         // test escrow asset mismatch
-        EscrowSupplierNFT invalidEscrow = new EscrowSupplierNFT(owner, configHub, cashAsset, "", "");
+        EscrowSupplierNFT invalidEscrow = new EscrowSupplierNFT(configHub, cashAsset, "", "");
         setCanOpenSingle(address(invalidEscrow), true);
         vm.startPrank(user1);
         escrowNFT = invalidEscrow;

--- a/test/unit/Rolls.t.sol
+++ b/test/unit/Rolls.t.sol
@@ -131,7 +131,8 @@ contract RollsTest is BaseAssetPairTestSetup {
             takerNFT.calculateProviderLocked(expected.newTakerLocked, ltv, callStrikePercent)
         );
         // protocol fee
-        (expected.toProtocol,) = providerNFT.protocolFee(expected.newProviderLocked, duration, callStrikePercent);
+        (expected.toProtocol,) =
+            providerNFT.protocolFee(expected.newProviderLocked, duration, callStrikePercent);
         // _calculateTransferAmounts
         (uint takerSettled, int providerChange) = takerNFT.previewSettlement(oldTakerPos, newPrice);
         int providerSettled = int(oldTakerPos.providerLocked) + providerChange;
@@ -274,13 +275,10 @@ contract RollsTest is BaseAssetPairTestSetup {
     // happy cases
 
     function test_constructor() public {
-        Rolls newRolls = new Rolls(owner, takerNFT);
+        Rolls newRolls = new Rolls(takerNFT);
         assertEq(address(newRolls.takerNFT()), address(takerNFT));
-        assertEq(address(newRolls.configHub()), address(configHub));
-        assertEq(newRolls.unrescuableAsset(), address(0));
         assertEq(address(newRolls.cashAsset()), address(cashAsset));
         assertEq(newRolls.VERSION(), "0.2.0");
-        assertEq(newRolls.owner(), owner);
     }
 
     function test_createRollOffer() public {

--- a/test/unit/Rolls.t.sol
+++ b/test/unit/Rolls.t.sol
@@ -131,7 +131,7 @@ contract RollsTest is BaseAssetPairTestSetup {
             takerNFT.calculateProviderLocked(expected.newTakerLocked, ltv, callStrikePercent)
         );
         // protocol fee
-        (expected.toProtocol,) = providerNFT.protocolFee(expected.newProviderLocked, duration);
+        (expected.toProtocol,) = providerNFT.protocolFee(expected.newProviderLocked, duration, callStrikePercent);
         // _calculateTransferAmounts
         (uint takerSettled, int providerChange) = takerNFT.previewSettlement(oldTakerPos, newPrice);
         int providerSettled = int(oldTakerPos.providerLocked) + providerChange;

--- a/test/unit/Rolls.t.sol
+++ b/test/unit/Rolls.t.sol
@@ -278,7 +278,7 @@ contract RollsTest is BaseAssetPairTestSetup {
         Rolls newRolls = new Rolls(takerNFT);
         assertEq(address(newRolls.takerNFT()), address(takerNFT));
         assertEq(address(newRolls.cashAsset()), address(cashAsset));
-        assertEq(newRolls.VERSION(), "0.2.0");
+        assertEq(newRolls.VERSION(), "0.3.0");
     }
 
     function test_createRollOffer() public {

--- a/test/unit/Rolls.t.sol
+++ b/test/unit/Rolls.t.sol
@@ -514,38 +514,6 @@ contract RollsTest is BaseAssetPairTestSetup {
         );
     }
 
-    function test_pause() public {
-        // pause
-        vm.startPrank(owner);
-        vm.expectEmit(address(rolls));
-        emit Pausable.Paused(owner);
-        rolls.pause();
-        // paused view
-        assertTrue(rolls.paused());
-        // methods are paused
-        vm.startPrank(user1);
-
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        rolls.createOffer(0, 0, 0, 0, 0, 0, 0);
-
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        rolls.cancelOffer(0);
-
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        rolls.executeRoll(0, 0);
-    }
-
-    function test_unpause() public {
-        vm.startPrank(owner);
-        rolls.pause();
-        vm.expectEmit(address(rolls));
-        emit Pausable.Unpaused(owner);
-        rolls.unpause();
-        assertFalse(rolls.paused());
-        // check at least one method works now
-        createAndCheckRollOffer();
-    }
-
     // reverts
 
     function test_revert_createRollOffer() public {


### PR DESCRIPTION
removes pausing from all contracts, and ownership from all but ConfigHub. Admin functions on unowned protocol contracts use `onlyConfigHubOwner`.

:warning: `NoDeploy` fork tests are failing, since the deployed versions are different from what we're testing for