### PR TITLE
Remove admin setKeeper method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ CollarTakerNFT, LoansNFT, EscrowSupplierNFT, CollarProviderNFT:
   - Inheriting from updated BaseManaged (not ownable, not pausable).
   - Different constructor interface. 
   - Using `onlyConfigHubOwner` for admin methods.
+LoansNFT:
+  - admin method for setting keeper removed, users can choose a keeper when approving
 CollarTakerNFT:
   - `setOracle` is removed, and `settleAsCancelled` (for oracle failure) is added 
 CollarProviderNFT:

--- a/src/LoansNFT.sol
+++ b/src/LoansNFT.sol
@@ -40,7 +40,6 @@ import { ILoansNFT } from "./interfaces/ILoansNFT.sol";
  * - CollarTakerNFT and CollarProviderNFT: Ensure properly configured
  * - EscrowSupplierNFT: If allowing escrow, ensure properly configured
  * - This Contract: Set an allowed default swapper
- * - This Contract: Set allowed closing keeper if using keeper functionality
  */
 contract LoansNFT is ILoansNFT, BaseNFT {
     using SafeERC20 for IERC20;
@@ -62,12 +61,9 @@ contract LoansNFT is ILoansNFT, BaseNFT {
     /// @notice Stores loan information for each NFT ID
     mapping(uint loanId => LoanStored) internal loans;
     // borrowers that allow a keeper for loan closing for specific loans
-    mapping(address sender => mapping(uint loanId => bool enabled)) public keeperApprovedFor;
+    mapping(address sender => mapping(uint loanId => address keeper)) public keeperApprovedFor;
 
     // ----- Admin state ----- //
-    // optional keeper (set by contract owner) that's useful for the time-sensitive
-    // swap back during loan closing
-    address public closingKeeper;
     // contracts allowed for swaps
     EnumerableSet.AddressSet internal allowedSwappers;
     // a convenience view to allow querying for a swapper onchain / FE without subgraph
@@ -352,28 +348,23 @@ contract LoansNFT is ILoansNFT, BaseNFT {
     }
 
     /**
-     * @notice Allows or disallows a keeper for closing a specific loan on behalf of a caller
+     * @notice Sets a keeper for closing a specific loan on behalf of a loan holder.
      * A user that sets this allowance with the intention for the keeper to closeLoan
      * has to also ensure cash approval to this contract that should be valid when
      * closeLoan is called by the keeper.
+     * To unset, set keeper to address(0).
+     * If the loan is transferred to another owner, this approval will become invalid, because the loan
+     * is held by someone else. However, if it is transferred back to the original approver, the approval
+     * will become valid again.
      * @param loanId specific loanId which the user approves the keeper to close
-     * @param enabled True to allow the keeper, false to disallow
+     * @param keeper address of the keeper the user approves
      */
-    function setKeeperApproved(uint loanId, bool enabled) external {
-        keeperApprovedFor[msg.sender][loanId] = enabled;
-        emit ClosingKeeperApproved(msg.sender, loanId, enabled);
+    function setKeeperFor(uint loanId, address keeper) external {
+        keeperApprovedFor[msg.sender][loanId] = keeper;
+        emit ClosingKeeperApproved(msg.sender, loanId, keeper);
     }
 
     // ----- Admin methods ----- //
-
-    /// @notice Sets the address of the single allowed closing keeper. Alternative decentralized keeper
-    /// arrangements can be added via composability, e.g., a contract that would hold the NFTs (thus
-    /// will be able to perform actions) and allow incentivised keepers to call it.
-    /// @dev only configHub owner
-    function setKeeper(address keeper) external onlyConfigHubOwner {
-        emit ClosingKeeperUpdated(closingKeeper, keeper);
-        closingKeeper = keeper;
-    }
 
     /// @notice Enables or disables swappers and sets the defaultSwapper view.
     /// When no swapper is allowed, opening and closing loans will not be possible, only cancelling.
@@ -782,11 +773,7 @@ contract LoansNFT is ILoansNFT, BaseNFT {
     their loans that are about to be closed, and only via a more complex "slippage" attack.
     */
     function _isSenderOrKeeperFor(address authorizedSender, uint loanId) internal view returns (bool) {
-        bool isSender = msg.sender == authorizedSender; // is the auth target
-        bool isKeeper = msg.sender == closingKeeper;
-        // our auth target allows the keeper
-        bool _keeperApproved = keeperApprovedFor[authorizedSender][loanId];
-        return isSender || (_keeperApproved && isKeeper);
+        return msg.sender == authorizedSender || msg.sender == keeperApprovedFor[authorizedSender][loanId];
     }
 
     function _newLoanIdCheck(uint takerId) internal view returns (uint loanId) {

--- a/src/interfaces/ILoansNFT.sol
+++ b/src/interfaces/ILoansNFT.sol
@@ -79,8 +79,7 @@ interface ILoansNFT {
         uint escrowId
     );
     event LoanCancelled(uint indexed loanId, address indexed sender);
-    event ClosingKeeperApproved(address indexed sender, uint indexed loanId, bool indexed enabled);
-    event ClosingKeeperUpdated(address indexed previousKeeper, address indexed newKeeper);
+    event ClosingKeeperApproved(address indexed sender, uint indexed loanId, address indexed keeper);
     event SwapperSet(address indexed swapper, bool indexed allowed, bool indexed setDefault);
     event EscrowSettled(uint indexed escrowId, uint toEscrow, uint fromEscrow, uint leftOver);
 }

--- a/test/integration/full-protocol/BaseAssetPairForkTest.sol
+++ b/test/integration/full-protocol/BaseAssetPairForkTest.sol
@@ -394,7 +394,6 @@ abstract contract BaseAssetPairForkTest is Test {
         address[] memory oneSwapper = new address[](1);
         oneSwapper[0] = address(pair.swapperUniV3);
         assertEq(pair.loansContract.allAllowedSwappers(), oneSwapper);
-        assertEq(pair.loansContract.closingKeeper(), address(0));
 
         // escrow
         assertEq(pair.escrowNFT.VERSION(), "0.3.0");

--- a/test/unit/Loans.admin.t.sol
+++ b/test/unit/Loans.admin.t.sol
@@ -21,21 +21,7 @@ contract LoansAdminTest is LoansTestBase {
         vm.startPrank(user1);
 
         vm.expectRevert("BaseManaged: not configHub owner");
-        loans.setKeeper(keeper);
-
-        vm.expectRevert("BaseManaged: not configHub owner");
         loans.setSwapperAllowed(address(0), true, true);
-    }
-
-    function test_setKeeper() public {
-        assertEq(loans.closingKeeper(), address(0));
-
-        vm.startPrank(owner);
-        vm.expectEmit(address(loans));
-        emit ILoansNFT.ClosingKeeperUpdated(address(0), keeper);
-        loans.setKeeper(keeper);
-
-        assertEq(loans.closingKeeper(), keeper);
     }
 
     function test_setSwapperAllowed() public {

--- a/test/unit/Loans.basic.reverts.t.sol
+++ b/test/unit/Loans.basic.reverts.t.sol
@@ -292,16 +292,13 @@ contract LoansBasicRevertsTest is LoansTestBase {
         (uint loanId,, uint loanAmount) = createAndCheckLoan();
         skip(duration);
 
-        vm.startPrank(owner);
-        loans.setKeeper(keeper);
-
         vm.startPrank(keeper);
         // keeper was not allowed by user
         vm.expectRevert("loans: not NFT owner or allowed keeper");
         loans.closeLoan(loanId, defaultSwapParams(0));
 
         vm.startPrank(user1);
-        loans.setKeeperApproved(0, true);
+        loans.setKeeperFor(0, keeper);
         // approved wrong loan
         vm.startPrank(keeper);
         vm.expectRevert("loans: not NFT owner or allowed keeper");
@@ -309,7 +306,7 @@ contract LoansBasicRevertsTest is LoansTestBase {
 
         // correct loan
         vm.startPrank(user1);
-        loans.setKeeperApproved(loanId, true);
+        loans.setKeeperFor(loanId, keeper);
 
         vm.startPrank(user1);
         // transfer invalidates approval
@@ -322,6 +319,9 @@ contract LoansBasicRevertsTest is LoansTestBase {
         // transfer back
         vm.startPrank(provider);
         loans.transferFrom(provider, user1, loanId);
+        // not keeper cannot call (provider is calling)
+        vm.expectRevert("loans: not NFT owner or allowed keeper");
+        loans.closeLoan(loanId, defaultSwapParams(0));
 
         // should work now
         vm.startPrank(user1);

--- a/test/unit/Loans.rolls.reverts.t.sol
+++ b/test/unit/Loans.rolls.reverts.t.sol
@@ -174,12 +174,10 @@ contract LoansRollsRevertsTest is LoansRollTestBase {
         // Create a loan
         (uint loanId,,) = createAndCheckLoan();
         uint rollId = createRollOffer(loanId);
-        vm.startPrank(owner);
-        loans.setKeeper(keeper);
 
         // Allow the keeper to close the loan (but not roll)
         vm.startPrank(user1);
-        loans.setKeeperApproved(loanId, true);
+        loans.setKeeperFor(loanId, keeper);
 
         // Attempt to roll the loan as the keeper
         vm.startPrank(keeper);


### PR DESCRIPTION
Instead of an admin method, anyone can set their own keeper (specific for sender and loan).